### PR TITLE
Change order of positional arguments (obs first)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ import scoringrules as sr
 import numpy as np
 
 obs = np.random.randn(100)
-fcts = obs[:,None] + np.random.randn(100, 21) * 0.1
-sr.crps_ensemble(fcts, obs)
+fct = obs[:,None] + np.random.randn(100, 21) * 0.1
+sr.crps_ensemble(obs, fct)
 ```
 
 ## Metrics

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,8 +32,8 @@ import scoringrules as sr
 import numpy as np
 
 obs = np.random.randn(100)
-fcts = obs[:,None] + np.random.randn(100, 21) * 0.1
-sr.crps_ensemble(fcts, obs)
+fct = obs[:,None] + np.random.randn(100, 21) * 0.1
+sr.crps_ensemble(obs, fct)
 ```
 
 ## Metrics

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -17,21 +17,21 @@ sr.crps_normal(0.1, 1.2, 0.3)
 
 # on arrays
 sr.brier_score(np.random.uniform(0, 1, 100), np.random.binomial(1, 0.5, 100))
-sr.crps_lognormal(np.random.randn(100), np.random.uniform(0.5, 1.5, 100), np.random.lognormal(0, 1, 100))
+sr.crps_lognormal(np.random.lognormal(0, 1, 100), np.random.randn(100), np.random.uniform(0.5, 1.5, 100))
 
 # ensemble metrics
 obs = np.random.randn(100)
-fcts = obs[:,None] + np.random.randn(100, 21) * 0.1
+fct = obs[:,None] + np.random.randn(100, 21) * 0.1
 
-sr.crps_ensemble(fcts, obs)
-sr.error_spread_score(fcts, obs)
+sr.crps_ensemble(obs, fct)
+sr.error_spread_score(obs, fct)
 
 # multivariate ensemble metrics
 obs = np.random.randn(100,3)
-fcts = obs[:,None] + np.random.randn(100, 21, 3) * 0.1
+fct = obs[:,None] + np.random.randn(100, 21, 3) * 0.1
 
-sr.energy_score(fcts, obs)
-sr.variogram_score(fcts, obs)
+sr.energy_score(obs, fct)
+sr.variogram_score(obs, fct)
 ```
 
 For the univariate ensemble metrics, the ensemble dimension is on the last axis unless you specify otherwise with the `axis` argument. For the multivariate ensemble metrics, the ensemble dimension and the variable dimension are on the second last and last axis respectively, unless specified otherwise with `m_axis` and `v_axis`.

--- a/scoringrules/_brier.py
+++ b/scoringrules/_brier.py
@@ -7,8 +7,8 @@ if tp.TYPE_CHECKING:
 
 
 def brier_score(
-    forecasts: "ArrayLike",
     observations: "ArrayLike",
+    forecasts: "ArrayLike",
     /,
     *,
     backend: "Backend" = None,
@@ -24,10 +24,10 @@ def brier_score(
 
     Parameters
     ----------
-    forecasts : NDArray
-        Forecasted probabilities between 0 and 1.
     observations: NDArray
         Observed outcome, either 0 or 1.
+    forecasts : NDArray
+        Forecasted probabilities between 0 and 1.
     backend: str
         The name of the backend used for computations. Defaults to 'numpy'.
 

--- a/scoringrules/_energy.py
+++ b/scoringrules/_energy.py
@@ -30,11 +30,11 @@ def energy_score(
 
     Parameters
     ----------
+    observations: Array
+        The observed values, where the variables dimension is by default the last axis.
     forecasts: Array
         The predicted forecast ensemble, where the ensemble dimension is by default
         represented by the second last axis and the variables dimension by the last axis.
-    observations: Array
-        The observed values, where the variables dimension is by default the last axis.
     m_axis: int
         The axis corresponding to the ensemble dimension on the forecasts array. Defaults to -2.
     v_axis: int
@@ -85,11 +85,11 @@ def twenergy_score(
 
     Parameters
     ----------
+    observations: ArrayLike of shape (...,D)
+        The observed values, where the variables dimension is by default the last axis.
     forecasts: ArrayLike of shape (..., M, D)
         The predicted forecast ensemble, where the ensemble dimension is by default
         represented by the second last axis and the variables dimension by the last axis.
-    observations: ArrayLike of shape (...,D)
-        The observed values, where the variables dimension is by default the last axis.
     v_func: tp.Callable
         Chaining function used to emphasise particular outcomes.
     m_axis: int
@@ -136,11 +136,11 @@ def owenergy_score(
 
     Parameters
     ----------
+    observations: ArrayLike of shape (...,D)
+        The observed values, where the variables dimension is by default the last axis.
     forecasts: ArrayLike of shape (..., M, D)
         The predicted forecast ensemble, where the ensemble dimension is by default
         represented by the second last axis and the variables dimension by the last axis.
-    observations: ArrayLike of shape (...,D)
-        The observed values, where the variables dimension is by default the last axis.
     w_func: tp.Callable
         Weight function used to emphasise particular outcomes.
     m_axis: int
@@ -161,16 +161,16 @@ def owenergy_score(
         forecasts, observations, m_axis, v_axis, backend=backend
     )
 
-    fcts_weights = B.apply_along_axis(w_func, forecasts, -1)
+    fct_weights = B.apply_along_axis(w_func, forecasts, -1)
     obs_weights = B.apply_along_axis(w_func, observations, -1)
 
     if B.name == "numba":
         return energy._owenergy_score_gufunc(
-            forecasts, observations, fcts_weights, obs_weights
+            forecasts, observations, fct_weights, obs_weights
         )
 
     return energy.ownrg(
-        forecasts, observations, fcts_weights, obs_weights, backend=backend
+        forecasts, observations, fct_weights, obs_weights, backend=backend
     )
 
 
@@ -202,11 +202,11 @@ def vrenergy_score(
 
     Parameters
     ----------
+    observations: ArrayLike of shape (...,D)
+        The observed values, where the variables dimension is by default the last axis.
     forecasts: ArrayLike of shape (..., M, D)
         The predicted forecast ensemble, where the ensemble dimension is by default
         represented by the second last axis and the variables dimension by the last axis.
-    observations: ArrayLike of shape (...,D)
-        The observed values, where the variables dimension is by default the last axis.
     w_func: tp.Callable
         Weight function used to emphasise particular outcomes.
     m_axis: int
@@ -227,14 +227,14 @@ def vrenergy_score(
         forecasts, observations, m_axis, v_axis, backend=backend
     )
 
-    fcts_weights = B.apply_along_axis(w_func, forecasts, -1)
+    fct_weights = B.apply_along_axis(w_func, forecasts, -1)
     obs_weights = B.apply_along_axis(w_func, observations, -1)
 
     if backend == "numba":
         return energy._vrenergy_score_gufunc(
-            forecasts, observations, fcts_weights, obs_weights
+            forecasts, observations, fct_weights, obs_weights
         )
 
     return energy.vrnrg(
-        forecasts, observations, fcts_weights, obs_weights, backend=backend
+        forecasts, observations, fct_weights, obs_weights, backend=backend
     )

--- a/scoringrules/_energy.py
+++ b/scoringrules/_energy.py
@@ -9,8 +9,8 @@ if tp.TYPE_CHECKING:
 
 
 def energy_score(
-    forecasts: "Array",
     observations: "Array",
+    forecasts: "Array",
     /,
     m_axis: int = -2,
     v_axis: int = -1,
@@ -49,19 +49,19 @@ def energy_score(
         The computed Energy Score.
     """
     backend = backend if backend is not None else backends._active
-    forecasts, observations = multivariate_array_check(
-        forecasts, observations, m_axis, v_axis, backend=backend
+    observations, forecasts = multivariate_array_check(
+        observations, forecasts, m_axis, v_axis, backend=backend
     )
 
     if backend == "numba":
-        return energy._energy_score_gufunc(forecasts, observations)
+        return energy._energy_score_gufunc(observations, forecasts)
 
-    return energy.nrg(forecasts, observations, backend=backend)
+    return energy.nrg(observations, forecasts, backend=backend)
 
 
 def twenergy_score(
-    forecasts: "Array",
     observations: "Array",
+    forecasts: "Array",
     v_func: tp.Callable[["ArrayLike"], "ArrayLike"],
     /,
     m_axis: int = -2,
@@ -104,15 +104,15 @@ def twenergy_score(
     twenergy_score: ArrayLike of shape (...)
         The computed Threshold-Weighted Energy Score.
     """
-    forecasts, observations = map(v_func, (forecasts, observations))
+    observations, forecasts = map(v_func, (observations, forecasts))
     return energy_score(
-        forecasts, observations, m_axis=m_axis, v_axis=v_axis, backend=backend
+        observations, forecasts, m_axis=m_axis, v_axis=v_axis, backend=backend
     )
 
 
 def owenergy_score(
-    forecasts: "Array",
     observations: "Array",
+    forecasts: "Array",
     w_func: tp.Callable[["ArrayLike"], "ArrayLike"],
     /,
     m_axis: int = -2,
@@ -157,8 +157,8 @@ def owenergy_score(
     """
     B = backends.active if backend is None else backends[backend]
 
-    forecasts, observations = multivariate_array_check(
-        forecasts, observations, m_axis, v_axis, backend=backend
+    observations, forecasts = multivariate_array_check(
+        observations, forecasts, m_axis, v_axis, backend=backend
     )
 
     fct_weights = B.apply_along_axis(w_func, forecasts, -1)
@@ -166,17 +166,17 @@ def owenergy_score(
 
     if B.name == "numba":
         return energy._owenergy_score_gufunc(
-            forecasts, observations, fct_weights, obs_weights
+            observations, forecasts, obs_weights, fct_weights
         )
 
     return energy.ownrg(
-        forecasts, observations, fct_weights, obs_weights, backend=backend
+        observations, forecasts, obs_weights, fct_weights, backend=backend
     )
 
 
 def vrenergy_score(
-    forecasts: "Array",
     observations: "Array",
+    forecasts: "Array",
     w_func: tp.Callable[["ArrayLike"], "ArrayLike"],
     /,
     *,
@@ -223,8 +223,8 @@ def vrenergy_score(
     """
     B = backends.active if backend is None else backends[backend]
 
-    forecasts, observations = multivariate_array_check(
-        forecasts, observations, m_axis, v_axis, backend=backend
+    observations, forecasts = multivariate_array_check(
+        observations, forecasts, m_axis, v_axis, backend=backend
     )
 
     fct_weights = B.apply_along_axis(w_func, forecasts, -1)
@@ -232,9 +232,9 @@ def vrenergy_score(
 
     if backend == "numba":
         return energy._vrenergy_score_gufunc(
-            forecasts, observations, fct_weights, obs_weights
+            observations, forecasts, obs_weights, fct_weights
         )
 
     return energy.vrnrg(
-        forecasts, observations, fct_weights, obs_weights, backend=backend
+        observations, forecasts, obs_weights, fct_weights, backend=backend
     )

--- a/scoringrules/_error_spread.py
+++ b/scoringrules/_error_spread.py
@@ -8,8 +8,8 @@ if tp.TYPE_CHECKING:
 
 
 def error_spread_score(
-    forecasts: "Array",
     observations: "ArrayLike",
+    forecasts: "Array",
     /,
     axis: int = -1,
     *,
@@ -19,11 +19,11 @@ def error_spread_score(
 
     Parameters
     ----------
+    observations: ArrayLike
+        The observed values.
     forecasts: Array
         The predicted forecast ensemble, where the ensemble dimension is by default
         represented by the last axis.
-    observations: ArrayLike
-        The observed values.
     axis: int
         The axis corresponding to the ensemble. Default is the last axis.
     backend: str
@@ -35,16 +35,12 @@ def error_spread_score(
         An array of error spread scores for each ensemble forecast, which should be averaged to get meaningful values.
     """
     B = backends.active if backend is None else backends[backend]
-    forecasts, observations = map(B.asarray, (forecasts, observations))
+    observations, forecasts = map(B.asarray, (observations, forecasts))
 
     if axis != -1:
         forecasts = B.moveaxis(forecasts, axis, -1)
 
     if B.name == "numba":
-        return error_spread._ess_gufunc(forecasts, observations)
+        return error_spread._ess_gufunc(observations, forecasts)
 
-    return error_spread.ess(forecasts, observations, backend=backend)
-
-    # \[
-    #     ESS = \left(s^2 - e^2 - e \cdot s \cdot g\right)^2
-    # \]
+    return error_spread.ess(observations, forecasts, backend=backend)

--- a/scoringrules/_logs.py
+++ b/scoringrules/_logs.py
@@ -7,9 +7,9 @@ if tp.TYPE_CHECKING:
 
 
 def logs_normal(
+    observation: "ArrayLike",
     mu: "ArrayLike",
     sigma: "ArrayLike",
-    observation: "ArrayLike",
     /,
     *,
     negative: bool = True,
@@ -21,12 +21,12 @@ def logs_normal(
 
     Parameters
     ----------
+    observations: ArrayLike
+        The observed values.
     mu: ArrayLike
         Mean of the forecast normal distribution.
     sigma: ArrayLike
         Standard deviation of the forecast normal distribution.
-    observation: ArrayLike
-        The observed values.
     backend: str, optional
         The backend used for computations.
 
@@ -42,5 +42,5 @@ def logs_normal(
     >>> 0.033898
     """
     return logarithmic.normal(
-        mu, sigma, observation, negative=negative, backend=backend
+        observation, mu, sigma, negative=negative, backend=backend
     )

--- a/scoringrules/_variogram.py
+++ b/scoringrules/_variogram.py
@@ -9,8 +9,8 @@ if tp.TYPE_CHECKING:
 
 
 def variogram_score(
-    forecasts: "Array",
     observations: "Array",
+    forecasts: "Array",
     /,
     m_axis: int = -2,
     v_axis: int = -1,
@@ -51,19 +51,19 @@ def variogram_score(
     variogram_score: Array
         The computed Variogram Score.
     """
-    forecasts, observations = multivariate_array_check(
-        forecasts, observations, m_axis, v_axis, backend=backend
+    observations, forecasts = multivariate_array_check(
+        observations, forecasts, m_axis, v_axis, backend=backend
     )
 
     if backend == "numba":
-        return variogram._variogram_score_gufunc(forecasts, observations, p)
+        return variogram._variogram_score_gufunc(observations, forecasts, p)
 
-    return variogram.vs(forecasts, observations, p, backend=backend)
+    return variogram.vs(observations, forecasts, p, backend=backend)
 
 
 def twvariogram_score(
-    forecasts: "Array",
     observations: "Array",
+    forecasts: "Array",
     v_func: tp.Callable,
     /,
     m_axis: int = -2,
@@ -108,15 +108,15 @@ def twvariogram_score(
     twvariogram_score: ArrayLike of shape (...)
         The computed Threshold-Weighted Variogram Score.
     """
-    forecasts, observations = map(v_func, (forecasts, observations))
+    observations, forecasts = map(v_func, (observations, forecasts))
     return variogram_score(
-        forecasts, observations, m_axis, v_axis, p=p, backend=backend
+        observations, forecasts, m_axis, v_axis, p=p, backend=backend
     )
 
 
 def owvariogram_score(
-    forecasts: "Array",
     observations: "Array",
+    forecasts: "Array",
     w_func: tp.Callable,
     /,
     m_axis: int = -2,
@@ -165,26 +165,26 @@ def owvariogram_score(
     """
     B = backends.active if backend is None else backends[backend]
 
-    forecasts, observations = multivariate_array_check(
-        forecasts, observations, m_axis, v_axis, backend=backend
+    observations, forecasts = multivariate_array_check(
+        observations, forecasts, m_axis, v_axis, backend=backend
     )
 
-    fcts_weights = B.apply_along_axis(w_func, forecasts, -1)
     obs_weights = B.apply_along_axis(w_func, observations, -1)
+    fct_weights = B.apply_along_axis(w_func, forecasts, -1)
 
     if backend == "numba":
         return variogram._owvariogram_score_gufunc(
-            forecasts, observations, p, fcts_weights, obs_weights
+            observations, forecasts, p, obs_weights, fct_weights
         )
 
     return variogram.owvs(
-        forecasts, observations, fcts_weights, obs_weights, p=p, backend=backend
+        observations, forecasts, obs_weights, fct_weights, p=p, backend=backend
     )
 
 
 def vrvariogram_score(
-    forecasts: "Array",
     observations: "Array",
+    forecasts: "Array",
     w_func: tp.Callable,
     /,
     m_axis: int = -2,
@@ -211,11 +211,11 @@ def vrvariogram_score(
 
     Parameters
     ----------
+    observations: Array
+        The observed values, where the variables dimension is by default the last axis.
     forecasts: Array
         The predicted forecast ensemble, where the ensemble dimension is by default
         represented by the second last axis and the variables dimension by the last axis.
-    observations: Array
-        The observed values, where the variables dimension is by default the last axis.
     p: float
         The order of the Variogram Score. Typical values are 0.5, 1.0 or 2.0. Defaults to 1.0.
     w_func: tp.Callable
@@ -234,18 +234,18 @@ def vrvariogram_score(
     """
     B = backends.active if backend is None else backends[backend]
 
-    forecasts, observations = multivariate_array_check(
-        forecasts, observations, m_axis, v_axis, backend=backend
+    observations, forecasts = multivariate_array_check(
+        observations, forecasts, m_axis, v_axis, backend=backend
     )
 
-    fcts_weights = B.apply_along_axis(w_func, forecasts, -1)
     obs_weights = B.apply_along_axis(w_func, observations, -1)
+    fct_weights = B.apply_along_axis(w_func, forecasts, -1)
 
     if backend == "numba":
         return variogram._vrvariogram_score_gufunc(
-            forecasts, observations, p, fcts_weights, obs_weights
+            observations, forecasts, p, obs_weights, fct_weights
         )
 
     return variogram.vrvs(
-        forecasts, observations, fcts_weights, obs_weights, p=p, backend=backend
+        observations, forecasts, obs_weights, fct_weights, p=p, backend=backend
     )

--- a/scoringrules/core/brier.py
+++ b/scoringrules/core/brier.py
@@ -9,16 +9,16 @@ EPSILON = 1e-5
 
 
 def brier_score(
-    fcts: "ArrayLike", obs: "ArrayLike", backend: "Backend" = None
+    obs: "ArrayLike", fct: "ArrayLike", backend: "Backend" = None
 ) -> "Array":
     """Compute the Brier Score for predicted probabilities of events."""
     B = backends.active if backend is None else backends[backend]
-    fcts, obs = map(B.asarray, (fcts, obs))
+    obs, fct = map(B.asarray, (obs, fct))
 
-    if B.any(fcts < 0.0) or B.any(fcts > 1.0 + EPSILON):
+    if B.any(fct < 0.0) or B.any(fct > 1.0 + EPSILON):
         raise ValueError("Forecasted probabilities must be within 0 and 1.")
 
     if not set(B.unique_values(obs)) <= {0, 1}:
         raise ValueError("Observations must be 0, 1, or NaN.")
 
-    return B.asarray((fcts - obs) ** 2)
+    return B.asarray((fct - obs) ** 2)

--- a/scoringrules/core/crps/_approx.py
+++ b/scoringrules/core/crps/_approx.py
@@ -7,18 +7,18 @@ if tp.TYPE_CHECKING:
 
 
 def ensemble(
-    fcts: "Array",
     obs: "ArrayLike",
+    fct: "Array",
     estimator: str = "pwm",
     backend: "Backend" = None,
 ) -> "Array":
     """Compute the CRPS for a finite ensemble."""
     if estimator == "nrg":
-        out = _crps_ensemble_nrg(fcts, obs, backend=backend)
+        out = _crps_ensemble_nrg(obs, fct, backend=backend)
     elif estimator == "pwm":
-        out = _crps_ensemble_pwm(fcts, obs, backend=backend)
+        out = _crps_ensemble_pwm(obs, fct, backend=backend)
     elif estimator == "fair":
-        out = _crps_ensemble_fair(fcts, obs, backend=backend)
+        out = _crps_ensemble_fair(obs, fct, backend=backend)
     else:
         raise ValueError(
             f"{estimator} can only be used with `numpy` "
@@ -29,56 +29,56 @@ def ensemble(
 
 
 def _crps_ensemble_fair(
-    fcts: "Array", obs: "Array", backend: "Backend" = None
+    obs: "Array", fct: "Array", backend: "Backend" = None
 ) -> "Array":
     """Fair version of the CRPS estimator based on the energy form."""
     B = backends.active if backend is None else backends[backend]
-    M: int = fcts.shape[-1]
-    e_1 = B.sum(B.abs(obs[..., None] - fcts), axis=-1) / M
+    M: int = fct.shape[-1]
+    e_1 = B.sum(B.abs(obs[..., None] - fct), axis=-1) / M
     e_2 = B.sum(
-        B.abs(fcts[..., None] - fcts[..., None, :]),
+        B.abs(fct[..., None] - fct[..., None, :]),
         axis=(-1, -2),
     ) / (M * (M - 1))
     return e_1 - 0.5 * e_2
 
 
 def _crps_ensemble_nrg(
-    fcts: "Array", obs: "Array", backend: "Backend" = None
+    obs: "Array", fct: "Array", backend: "Backend" = None
 ) -> "Array":
     """CRPS estimator based on the energy form."""
     B = backends.active if backend is None else backends[backend]
-    M: int = fcts.shape[-1]
-    e_1 = B.sum(B.abs(obs[..., None] - fcts), axis=-1) / M
-    e_2 = B.sum(B.abs(fcts[..., None] - fcts[..., None, :]), (-1, -2)) / (M**2)
+    M: int = fct.shape[-1]
+    e_1 = B.sum(B.abs(obs[..., None] - fct), axis=-1) / M
+    e_2 = B.sum(B.abs(fct[..., None] - fct[..., None, :]), (-1, -2)) / (M**2)
     return e_1 - 0.5 * e_2
 
 
 def _crps_ensemble_pwm(
-    fcts: "Array", obs: "Array", backend: "Backend" = None
+    obs: "Array", fct: "Array", backend: "Backend" = None
 ) -> "Array":
     """CRPS estimator based on the probability weighted moment (PWM) form."""
     B = backends.active if backend is None else backends[backend]
-    M: int = fcts.shape[-1]
-    expected_diff = B.sum(B.abs(obs[..., None] - fcts), axis=-1) / M
-    β_0 = B.sum(fcts, axis=-1) / M
-    β_1 = B.sum(fcts * B.arange(M), axis=-1) / (M * (M - 1.0))
+    M: int = fct.shape[-1]
+    expected_diff = B.sum(B.abs(obs[..., None] - fct), axis=-1) / M
+    β_0 = B.sum(fct, axis=-1) / M
+    β_1 = B.sum(fct * B.arange(M), axis=-1) / (M * (M - 1.0))
     return expected_diff + β_0 - 2.0 * β_1
 
 
 def ow_ensemble(
-    fcts: "Array",
     obs: "Array",
-    fw: "Array",
+    fct: "Array",
     ow: "Array",
+    fw: "Array",
     backend: "Backend" = None,
 ) -> "Array":
     """Outcome-Weighted CRPS estimator based on the energy form."""
     B = backends.active if backend is None else backends[backend]
-    M: int = fcts.shape[-1]
+    M: int = fct.shape[-1]
     wbar = B.mean(fw, axis=-1)
-    e_1 = B.sum(B.abs(obs[..., None] - fcts) * fw, axis=-1) * ow / (M * wbar)
+    e_1 = B.sum(B.abs(obs[..., None] - fct) * fw, axis=-1) * ow / (M * wbar)
     e_2 = B.sum(
-        B.abs(fcts[..., None] - fcts[..., None, :]) * fw[..., None] * fw[..., None, :],
+        B.abs(fct[..., None] - fct[..., None, :]) * fw[..., None] * fw[..., None, :],
         axis=(-1, -2),
     )
     e_2 *= ow / (M**2 * wbar**2)
@@ -86,21 +86,21 @@ def ow_ensemble(
 
 
 def vr_ensemble(
-    fcts: "Array",
     obs: "Array",
-    fw: "Array",
+    fct: "Array",
     ow: "Array",
+    fw: "Array",
     backend: "Backend" = None,
 ) -> "Array":
     """Vertically Re-scaled CRPS estimator based on the energy form."""
     B = backends.active if backend is None else backends[backend]
-    M: int = fcts.shape[-1]
-    e_1 = B.sum(B.abs(obs[..., None] - fcts) * fw, axis=-1) * ow / M
+    M: int = fct.shape[-1]
+    e_1 = B.sum(B.abs(obs[..., None] - fct) * fw, axis=-1) * ow / M
     e_2 = B.sum(
-        B.abs(B.expand_dims(fcts, axis=-1) - B.expand_dims(fcts, axis=-2))
+        B.abs(B.expand_dims(fct, axis=-1) - B.expand_dims(fct, axis=-2))
         * (B.expand_dims(fw, axis=-1) * B.expand_dims(fw, axis=-2)),
         axis=(-1, -2),
     ) / (M**2)
-    e_3 = B.mean(B.abs(fcts) * fw, axis=-1) - B.abs(obs) * ow
+    e_3 = B.mean(B.abs(fct) * fw, axis=-1) - B.abs(obs) * ow
     e_3 *= B.mean(fw, axis=1) - ow
     return e_1 - 0.5 * e_2 + e_3

--- a/scoringrules/core/crps/_closed.py
+++ b/scoringrules/core/crps/_closed.py
@@ -8,7 +8,7 @@ if tp.TYPE_CHECKING:
 
 
 def normal(
-    mu: "ArrayLike", sigma: "ArrayLike", obs: "ArrayLike", backend: "Backend" = None
+    obs: "ArrayLike", mu: "ArrayLike", sigma: "ArrayLike", backend: "Backend" = None
 ) -> "Array":
     """Compute the CRPS for the normal distribution."""
     B = backends.active if backend is None else backends[backend]
@@ -22,9 +22,9 @@ def normal(
 
 
 def lognormal(
+    obs: "ArrayLike",
     mulog: "ArrayLike",
     sigmalog: "ArrayLike",
-    obs: "ArrayLike",
     backend: "Backend" = None,
 ) -> "Array":
     """Compute the CRPS for the lognormal distribution."""
@@ -40,7 +40,7 @@ def lognormal(
 
 
 def logistic(
-    mu: "ArrayLike", sigma: "ArrayLike", obs: "ArrayLike", backend: "Backend" = None
+    obs: "ArrayLike", mu: "ArrayLike", sigma: "ArrayLike", backend: "Backend" = None
 ) -> "Array":
     """Compute the CRPS for the normal distribution."""
     B = backends.active if backend is None else backends[backend]

--- a/scoringrules/core/energy/_gufuncs.py
+++ b/scoringrules/core/energy/_gufuncs.py
@@ -1,61 +1,56 @@
 import numpy as np
 from numba import guvectorize
-from numpy.typing import NDArray
-
-_NDArray = NDArray[np.float32 | np.float64]
 
 
 @guvectorize(
     [
-        "void(float32[:,:], float32[:], float32[:])",
-        "void(float64[:,:], float64[:], float64[:])",
+        "void(float32[:], float32[:,:], float32[:])",
+        "void(float64[:], float64[:,:], float64[:])",
     ],
-    "(m,d),(d)->()",
+    "(d),(m,d)->()",
 )
 def _energy_score_gufunc(
-    forecasts: _NDArray,
-    observations: _NDArray,
-    out: _NDArray,
+    obs: np.ndarray,
+    fct: np.ndarray,
+    out: np.ndarray,
 ):
     """Compute the Energy Score for a finite ensemble."""
-    M = forecasts.shape[0]
+    M = fct.shape[0]
 
     e_1 = 0.0
     e_2 = 0.0
     for i in range(M):
-        e_1 += float(np.linalg.norm(forecasts[i] - observations))
+        e_1 += float(np.linalg.norm(fct[i] - obs))
         for j in range(M):
-            e_2 += float(np.linalg.norm(forecasts[i] - forecasts[j]))
+            e_2 += float(np.linalg.norm(fct[i] - fct[j]))
 
     out[0] = e_1 / M - 0.5 / (M**2) * e_2
 
 
 @guvectorize(
     [
-        "void(float32[:,:], float32[:], float32[:], float32[:], float32[:])",
-        "void(float64[:,:], float64[:], float64[:], float64[:], float64[:])",
+        "void(float32[:], float32[:,:], float32[:], float32[:], float32[:])",
+        "void(float64[:], float64[:,:], float64[:], float64[:], float64[:])",
     ],
-    "(m,d),(d),(m),()->()",
+    "(d),(m,d),(),(m)->()",
 )
 def _owenergy_score_gufunc(
-    forecasts: _NDArray,
-    observations: _NDArray,
-    fw: _NDArray,
-    ow: _NDArray,
-    out: _NDArray,
+    obs: np.ndarray,
+    fct: np.ndarray,
+    ow: np.ndarray,
+    fw: np.ndarray,
+    out: np.ndarray,
 ):
     """Compute the Outcome-Weighted Energy Score for a finite ensemble."""
-    M = forecasts.shape[0]
+    M = fct.shape[0]
     ow = ow[0]
 
     e_1 = 0.0
     e_2 = 0.0
     for i in range(M):
-        e_1 += float(np.linalg.norm(forecasts[i] - observations) * fw[i] * ow)
+        e_1 += float(np.linalg.norm(fct[i] - obs) * fw[i] * ow)
         for j in range(M):
-            e_2 += float(
-                np.linalg.norm(forecasts[i] - forecasts[j]) * fw[i] * fw[j] * ow
-            )
+            e_2 += float(np.linalg.norm(fct[i] - fct[j]) * fw[i] * fw[j] * ow)
 
     wbar = np.mean(fw)
 
@@ -64,33 +59,33 @@ def _owenergy_score_gufunc(
 
 @guvectorize(
     [
-        "void(float32[:,:], float32[:], float32[:], float32[:], float32[:])",
-        "void(float64[:,:], float64[:], float64[:], float64[:], float64[:])",
+        "void(float32[:], float32[:,:], float32[:], float32[:], float32[:])",
+        "void(float64[:], float64[:,:], float64[:], float64[:], float64[:])",
     ],
-    "(m,d),(d),(m),()->()",
+    "(d),(m,d),(),(m)->()",
 )
 def _vrenergy_score_gufunc(
-    forecasts: _NDArray,
-    observations: _NDArray,
-    fw: _NDArray,
-    ow: _NDArray,
-    out: _NDArray,
+    obs: np.ndarray,
+    fct: np.ndarray,
+    ow: np.ndarray,
+    fw: np.ndarray,
+    out: np.ndarray,
 ):
     """Compute the Vertically Re-scaled Energy Score for a finite ensemble."""
-    M = forecasts.shape[0]
+    M = fct.shape[0]
     ow = ow[0]
 
     e_1 = 0.0
     e_2 = 0.0
     wabs_x = 0.0
     for i in range(M):
-        e_1 += float(np.linalg.norm(forecasts[i] - observations) * fw[i] * ow)
-        wabs_x += np.linalg.norm(forecasts[i]) * fw[i]
+        e_1 += float(np.linalg.norm(fct[i] - obs) * fw[i] * ow)
+        wabs_x += np.linalg.norm(fct[i]) * fw[i]
         for j in range(M):
-            e_2 += float(np.linalg.norm(forecasts[i] - forecasts[j]) * fw[i] * fw[j])
+            e_2 += float(np.linalg.norm(fct[i] - fct[j]) * fw[i] * fw[j])
 
     wabs_x = wabs_x / M
     wbar = np.mean(fw)
-    wabs_y = np.linalg.norm(observations) * ow
+    wabs_y = np.linalg.norm(obs) * ow
 
     out[0] = e_1 / M - 0.5 * e_2 / (M**2) + (wabs_x - wabs_y) * (wbar - ow)

--- a/scoringrules/core/energy/_score.py
+++ b/scoringrules/core/energy/_score.py
@@ -6,44 +6,40 @@ if tp.TYPE_CHECKING:
     from scoringrules.core.typing import Array, Backend
 
 
-def energy_score(
-    fcts: "Array", obs: "Array", backend=None  # (... M D)  # (... D)
-) -> "Array":
+def energy_score(obs: "Array", fct: "Array", backend=None) -> "Array":
     """
     Compute the energy score based on a finite ensemble.
 
     The ensemble and variables axes are on the second last and last dimensions respectively.
     """
     B = backends.active if backend is None else backends[backend]
-    M: int = fcts.shape[-2]
+    M: int = fct.shape[-2]
 
-    err_norm = B.norm(fcts - B.expand_dims(obs, -2), -1)  # (... M)
-    E_1 = B.sum(err_norm, -1) / M  # (...)
+    err_norm = B.norm(fct - B.expand_dims(obs, -2), -1)
+    E_1 = B.sum(err_norm, -1) / M
 
-    spread_norm = B.norm(
-        B.expand_dims(fcts, -3) - B.expand_dims(fcts, -2), -1
-    )  # (... M M)
-    E_2 = B.sum(spread_norm, (-2, -1)) / (M**2)  # (...)
+    spread_norm = B.norm(B.expand_dims(fct, -3) - B.expand_dims(fct, -2), -1)
+    E_2 = B.sum(spread_norm, (-2, -1)) / (M**2)
     return E_1 - 0.5 * E_2
 
 
 def owenergy_score(
-    fcts: "Array",  # (... M D)
     obs: "Array",  # (... D)
-    fw: "Array",  # (... M)
+    fct: "Array",  # (... M D)
     ow: "Array",  # (...)
+    fw: "Array",  # (... M)
     backend: "Backend" = None,
 ) -> "Array":
     """Compute the outcome-weighted energy score based on a finite ensemble."""
     B = backends.active if backend is None else backends[backend]
-    M = fcts.shape[-2]
+    M = fct.shape[-2]
     wbar = B.sum(fw, -1) / M
 
-    err_norm = B.norm(fcts - B.expand_dims(obs, -2), -1)  # (... M)
+    err_norm = B.norm(fct - B.expand_dims(obs, -2), -1)  # (... M)
     E_1 = B.sum(err_norm * fw * B.expand_dims(ow, -1), -1) / (M * wbar)  # (...)
 
     spread_norm = B.norm(
-        B.expand_dims(fcts, -2) - B.expand_dims(fcts, -3), -1
+        B.expand_dims(fct, -2) - B.expand_dims(fct, -3), -1
     )  # (... M M)
     fw_prod = B.expand_dims(fw, -1) * B.expand_dims(fw, -2)  # (... M M)
     spread_norm *= fw_prod * B.expand_dims(ow, (-2, -1))  # (... M M)
@@ -53,27 +49,27 @@ def owenergy_score(
 
 
 def vrenergy_score(
-    fcts: "Array",
     obs: "Array",
-    fw: "Array",
+    fct: "Array",
     ow: "Array",
+    fw: "Array",
     backend: "Backend" = None,
 ) -> "Array":
     """Compute the vertically re-scaled energy score based on a finite ensemble."""
     B = backends.active if backend is None else backends[backend]
-    M, D = fcts.shape[-2:]
+    M, D = fct.shape[-2:]
     wbar = B.sum(fw, -1) / M
 
-    err_norm = B.norm(fcts - B.expand_dims(obs, -2), -1)  # (... M)
+    err_norm = B.norm(fct - B.expand_dims(obs, -2), -1)  # (... M)
     err_norm *= fw * B.expand_dims(ow, -1)  # (... M)
     E_1 = B.sum(err_norm, -1) / M  # (...)
 
     spread_norm = B.norm(
-        B.expand_dims(fcts, -2) - B.expand_dims(fcts, -3), -1
+        B.expand_dims(fct, -2) - B.expand_dims(fct, -3), -1
     )  # (... M M)
     fw_prod = B.expand_dims(fw, -2) * B.expand_dims(fw, -1)  # (... M M)
     E_2 = B.sum(spread_norm * fw_prod, (-2, -1)) / (M**2)  # (...)
 
-    rhobar = B.sum(B.norm(fcts, -1) * fw, -1) / M  # (...)
+    rhobar = B.sum(B.norm(fct, -1) * fw, -1) / M  # (...)
     E_3 = (rhobar - B.norm(obs, -1) * ow) * (wbar - ow)  # (...)
     return E_1 - 0.5 * E_2 + E_3

--- a/scoringrules/core/error_spread/_gufunc.py
+++ b/scoringrules/core/error_spread/_gufunc.py
@@ -10,32 +10,30 @@ EPSILON = 1e-6
         "void(float32[:], float32[:], float32[:])",
         "void(float64[:], float64[:], float64[:])",
     ],
-    "(n),()->()",
+    "(),(n)->()",
 )
-def _error_spread_score_gufunc(
-    forecasts: np.ndarray, observation: np.ndarray, out: np.ndarray
-):
+def _error_spread_score_gufunc(obs: np.ndarray, fct: np.ndarray, out: np.ndarray):
     """Error spread score."""
-    M = forecasts.shape[0]
+    M = fct.shape[0]
     m = 0.0
     s = 0.0
     g = 0.0
     e = 0.0
 
     for i in range(M):
-        m += forecasts[i]
+        m += fct[i]
     m /= M
 
     for i in range(M):
-        s += (forecasts[i] - m) ** 2
+        s += (fct[i] - m) ** 2
     s /= M - 1
     s = np.sqrt(s)
 
     for i in range(M):
-        g += ((forecasts[i] - m) / s) ** 3
+        g += ((fct[i] - m) / s) ** 3
     g /= (M - 1) * (M - 2)
 
     for i in range(M):
-        e += forecasts[i] - observation[i]
+        e += fct[i] - obs[i]
 
     out[0] = (s**2 - e**2 - e * s * g) ** 2

--- a/scoringrules/core/error_spread/_score.py
+++ b/scoringrules/core/error_spread/_score.py
@@ -7,15 +7,13 @@ if tp.TYPE_CHECKING:
 
 
 def error_spread_score(
-    fcts: "Array", obs: "Array", backend: "Backend" = None
+    obs: "Array", fct: "Array", backend: "Backend" = None
 ) -> "Array":
     """Error spread score."""
     B = backends.active if backend is None else backends[backend]
-    M: int = fcts.shape[-1]
-    m = B.mean(fcts, axis=-1)
-    s = B.sqrt(B.sum((fcts - m[..., None]) ** 2, axis=-1) / (M - 1))
-    g = B.sum(((fcts - m[..., None]) / s[..., None]) ** 3, axis=-1) / (
-        (M - 1) * (M - 2)
-    )
+    M: int = fct.shape[-1]
+    m = B.mean(fct, axis=-1)
+    s = B.sqrt(B.sum((fct - m[..., None]) ** 2, axis=-1) / (M - 1))
+    g = B.sum(((fct - m[..., None]) / s[..., None]) ** 3, axis=-1) / ((M - 1) * (M - 2))
     e = m - obs
     return B.squeeze((s**2 - e**2 - e * s * g) ** 2)

--- a/scoringrules/core/logarithmic.py
+++ b/scoringrules/core/logarithmic.py
@@ -8,9 +8,9 @@ if tp.TYPE_CHECKING:
 
 
 def normal(
+    obs: "ArrayLike",
     mu: "ArrayLike",
     sigma: "ArrayLike",
-    obs: "ArrayLike",
     negative: bool = True,
     backend: "Backend" = None,
 ) -> "Array":

--- a/scoringrules/core/utils.py
+++ b/scoringrules/core/utils.py
@@ -4,8 +4,8 @@ _V_AXIS = -1
 _M_AXIS = -2
 
 
-def _multivariate_shape_compatibility(fcts, obs, m_axis) -> None:
-    f_shape = fcts.shape
+def _multivariate_shape_compatibility(obs, fct, m_axis) -> None:
+    f_shape = fct.shape
     o_shape = obs.shape
     o_shape_broadcast = o_shape[:m_axis] + (f_shape[m_axis],) + o_shape[m_axis:]
     if o_shape_broadcast != f_shape:
@@ -14,19 +14,19 @@ def _multivariate_shape_compatibility(fcts, obs, m_axis) -> None:
         )
 
 
-def _multivariate_shape_permute(fcts, obs, m_axis, v_axis, backend=None):
+def _multivariate_shape_permute(obs, fct, m_axis, v_axis, backend=None):
     B = backends.active if backend is None else backends[backend]
     v_axis_obs = v_axis - 1 if m_axis < v_axis else v_axis
-    fcts = B.moveaxis(fcts, (m_axis, v_axis), (_M_AXIS, _V_AXIS))
+    fct = B.moveaxis(fct, (m_axis, v_axis), (_M_AXIS, _V_AXIS))
     obs = B.moveaxis(obs, v_axis_obs, _V_AXIS)
-    return fcts, obs
+    return obs, fct
 
 
-def multivariate_array_check(fcts, obs, m_axis, v_axis, backend=None):
+def multivariate_array_check(obs, fct, m_axis, v_axis, backend=None):
     """Check and adapt the shapes of multivariate forecasts and observations arrays."""
     B = backends.active if backend is None else backends[backend]
-    fcts, obs = map(B.asarray, (fcts, obs))
-    m_axis = m_axis if m_axis >= 0 else fcts.ndim + m_axis
-    v_axis = v_axis if v_axis >= 0 else fcts.ndim + v_axis
-    _multivariate_shape_compatibility(fcts, obs, m_axis)
-    return _multivariate_shape_permute(fcts, obs, m_axis, v_axis, backend=backend)
+    obs, fct = map(B.asarray, (obs, fct))
+    m_axis = m_axis if m_axis >= 0 else fct.ndim + m_axis
+    v_axis = v_axis if v_axis >= 0 else fct.ndim + v_axis
+    _multivariate_shape_compatibility(obs, fct, m_axis)
+    return _multivariate_shape_permute(obs, fct, m_axis, v_axis, backend=backend)

--- a/scoringrules/core/variogram/_score.py
+++ b/scoringrules/core/variogram/_score.py
@@ -7,50 +7,50 @@ if tp.TYPE_CHECKING:
 
 
 def variogram_score(
-    fcst: "Array",  # (... M D)
     obs: "Array",  # (... D)
+    fct: "Array",  # (... M D)
     p: float = 1,
     backend: "Backend" = None,
 ) -> "Array":
     """Compute the Variogram Score for a multivariate finite ensemble."""
     B = backends.active if backend is None else backends[backend]
-    M: int = fcst.shape[-2]
-    fcst_diff = B.expand_dims(fcst, -2) - B.expand_dims(fcst, -1)  # (... M D D)
-    vfcts = B.sum(B.abs(fcst_diff) ** p, axis=-3) / M  # (... D D)
+    M: int = fct.shape[-2]
+    fct_diff = B.expand_dims(fct, -2) - B.expand_dims(fct, -1)  # (... M D D)
+    vfct = B.sum(B.abs(fct_diff) ** p, axis=-3) / M  # (... D D)
     obs_diff = B.expand_dims(obs, -2) - B.expand_dims(obs, -1)  # (... D D)
     vobs = B.abs(obs_diff) ** p  # (... D D)
-    return B.sum((vobs - vfcts) ** 2, axis=(-2, -1))  # (...)
+    return B.sum((vobs - vfct) ** 2, axis=(-2, -1))  # (...)
 
 
 def owvariogram_score(
-    fcst: "Array",
     obs: "Array",
-    fw: "Array",
+    fct: "Array",
     ow: "Array",
+    fw: "Array",
     p: float = 1,
     backend: "Backend" = None,
 ) -> "Array":
     """Compute the Outcome-Weighted Variogram Score for a multivariate finite ensemble."""
     B = backends.active if backend is None else backends[backend]
-    M: int = fcst.shape[-2]
+    M: int = fct.shape[-2]
     wbar = B.mean(fw, axis=-1)
 
-    fcst_diff = B.expand_dims(fcst, -2) - B.expand_dims(fcst, -1)  # (... M D D)
-    fcst_diff = B.abs(fcst_diff) ** p  # (... M D D)
+    fct_diff = B.expand_dims(fct, -2) - B.expand_dims(fct, -1)  # (... M D D)
+    fct_diff = B.abs(fct_diff) ** p  # (... M D D)
 
     obs_diff = B.expand_dims(obs, -2) - B.expand_dims(obs, -1)  # (... D D)
     obs_diff = B.abs(obs_diff) ** p  # (... D D)
-    del fcst, obs
+    del obs, fct
 
-    E_1 = (fcst_diff - B.expand_dims(obs_diff, -3)) ** 2  # (... M D D)
+    E_1 = (fct_diff - B.expand_dims(obs_diff, -3)) ** 2  # (... M D D)
     E_1 = B.sum(E_1, axis=(-2, -1))  # (... M)
     E_1 = B.sum(E_1 * fw * B.expand_dims(ow, -1), axis=-1) / (M * wbar)  # (...)
 
-    fcst_diff_spread = B.expand_dims(fcst_diff, -3) - B.expand_dims(
-        fcst_diff, -4
+    fct_diff_spread = B.expand_dims(fct_diff, -3) - B.expand_dims(
+        fct_diff, -4
     )  # (... M M D D)
     fw_prod = B.expand_dims(fw, -2) * B.expand_dims(fw, -1)  # (... M M)
-    E_2 = B.sum(fcst_diff_spread**2, axis=(-2, -1))  # (... M M)
+    E_2 = B.sum(fct_diff_spread**2, axis=(-2, -1))  # (... M M)
     E_2 *= fw_prod * B.expand_dims(ow, (-2, -1))  # (... M M)
     E_2 = B.sum(E_2, axis=(-2, -1)) / (M**2 * wbar**2)  # (...)
 
@@ -58,36 +58,36 @@ def owvariogram_score(
 
 
 def vrvariogram_score(
-    fcst: "Array",
     obs: "Array",
-    fw: "Array",
+    fct: "Array",
     ow: "Array",
+    fw: "Array",
     p: float = 1,
     backend: "Backend" = None,
 ) -> "Array":
     """Compute the Vertically Re-scaled Variogram Score for a multivariate finite ensemble."""
     B = backends.active if backend is None else backends[backend]
-    M: int = fcst.shape[-2]
+    M: int = fct.shape[-2]
     wbar = B.mean(fw, axis=-1)
 
-    fcst_diff = (
-        B.abs(B.expand_dims(fcst, -2) - B.expand_dims(fcst, -1)) ** p
+    fct_diff = (
+        B.abs(B.expand_dims(fct, -2) - B.expand_dims(fct, -1)) ** p
     )  # (... M D D)
     obs_diff = B.abs(B.expand_dims(obs, -2) - B.expand_dims(obs, -1)) ** p  # (... D D)
 
-    E_1 = (fcst_diff - B.expand_dims(obs_diff, axis=-3)) ** 2  # (... M D D)
+    E_1 = (fct_diff - B.expand_dims(obs_diff, axis=-3)) ** 2  # (... M D D)
     E_1 = B.sum(E_1, axis=(-2, -1))  # (... M)
     E_1 = B.sum(E_1 * fw * B.expand_dims(ow, axis=-1), axis=-1) / M  # (...)
 
     E_2 = (
-        B.expand_dims(fcst_diff, -3) - B.expand_dims(fcst_diff, -4)
+        B.expand_dims(fct_diff, -3) - B.expand_dims(fct_diff, -4)
     ) ** 2  # (... M M D D)
     E_2 = B.sum(E_2, axis=(-2, -1))  # (... M M)
 
     fw_prod = B.expand_dims(fw, axis=-2) * B.expand_dims(fw, axis=-1)  # (... M M)
     E_2 = B.sum(E_2 * fw_prod, axis=(-2, -1)) / (M**2)  # (...)
 
-    E_3 = B.sum(fcst_diff**2, axis=(-2, -1))  # (... M)
+    E_3 = B.sum(fct_diff**2, axis=(-2, -1))  # (... M)
     E_3 = B.sum(E_3 * fw, axis=-1) / M  # (...)
     E_3 -= B.sum(obs_diff**2, axis=(-2, -1)) * ow  # (...)
     E_3 *= wbar - ow  # (...)

--- a/tests/test_crps.py
+++ b/tests/test_crps.py
@@ -16,23 +16,23 @@ def test_ensemble(estimator, backend):
     obs = np.random.randn(N)
     mu = obs + np.random.randn(N) * 0.1
     sigma = abs(np.random.randn(N)) * 0.3
-    fcts = np.random.randn(N, ENSEMBLE_SIZE) * sigma[..., None] + mu[..., None]
+    fct = np.random.randn(N, ENSEMBLE_SIZE) * sigma[..., None] + mu[..., None]
 
     # test exceptions
     if backend in ["numpy", "jax", "torch", "tensorflow"]:
         if estimator not in ["nrg", "fair", "pwm"]:
             with pytest.raises(ValueError):
-                _crps.crps_ensemble(fcts, obs, estimator=estimator, backend=backend)
+                _crps.crps_ensemble(obs, fct, estimator=estimator, backend=backend)
             return
 
     # non-negative values
-    res = _crps.crps_ensemble(fcts, obs, estimator=estimator, backend=backend)
+    res = _crps.crps_ensemble(obs, fct, estimator=estimator, backend=backend)
     res = np.asarray(res)
     assert not np.any(res < 0.0)
 
     # approx zero when perfect forecast
-    perfect_fcts = obs[..., None] + np.random.randn(N, ENSEMBLE_SIZE) * 0.00001
-    res = _crps.crps_ensemble(perfect_fcts, obs, estimator=estimator, backend=backend)
+    perfect_fct = obs[..., None] + np.random.randn(N, ENSEMBLE_SIZE) * 0.00001
+    res = _crps.crps_ensemble(obs, perfect_fct, estimator=estimator, backend=backend)
     res = np.asarray(res)
     assert not np.any(res - 0.0 > 0.0001)
 
@@ -44,7 +44,7 @@ def test_normal(backend):
     sigma = abs(np.random.randn(N)) * 0.3
 
     # non-negative values
-    res = _crps.crps_normal(mu, sigma, obs, backend=backend)
+    res = _crps.crps_normal(obs, mu, sigma, backend=backend)
     res = np.asarray(res)
     assert not np.any(np.isnan(res))
     assert not np.any(res < 0.0)
@@ -52,7 +52,7 @@ def test_normal(backend):
     # approx zero when perfect forecast
     mu = obs + np.random.randn(N) * 1e-6
     sigma = abs(np.random.randn(N)) * 1e-6
-    res = _crps.crps_normal(mu, sigma, obs, backend=backend)
+    res = _crps.crps_normal(obs, mu, sigma, backend=backend)
     res = np.asarray(res)
 
     assert not np.any(np.isnan(res))
@@ -66,7 +66,7 @@ def test_lognormal(backend):
     sigmalog = abs(np.random.randn(N)) * 0.3
 
     # non-negative values
-    res = _crps.crps_lognormal(mulog, sigmalog, obs, backend=backend)
+    res = _crps.crps_lognormal(obs, mulog, sigmalog, backend=backend)
     res = np.asarray(res)
     assert not np.any(np.isnan(res))
     assert not np.any(res < 0.0)
@@ -74,7 +74,7 @@ def test_lognormal(backend):
     # approx zero when perfect forecast
     mulog = np.log(obs) + np.random.randn(N) * 1e-6
     sigmalog = abs(np.random.randn(N)) * 1e-6
-    res = _crps.crps_lognormal(mulog, sigmalog, obs, backend=backend)
+    res = _crps.crps_lognormal(obs, mulog, sigmalog, backend=backend)
     res = np.asarray(res)
 
     assert not np.any(np.isnan(res))

--- a/tests/test_energy.py
+++ b/tests/test_energy.py
@@ -13,9 +13,9 @@ N_VARS = 3
 @pytest.mark.parametrize("backend", BACKENDS)
 def test_energy_score(backend):
     obs = np.random.randn(N, N_VARS)
-    fcts = np.expand_dims(obs, axis=-2) + np.random.randn(N, ENSEMBLE_SIZE, N_VARS)
+    fct = np.expand_dims(obs, axis=-2) + np.random.randn(N, ENSEMBLE_SIZE, N_VARS)
 
-    res = energy_score(fcts, obs, backend=backend)
+    res = energy_score(obs, fct, backend=backend)
 
     if backend in ["numpy", "numba"]:
         assert isinstance(res, np.ndarray)

--- a/tests/test_error_spread.py
+++ b/tests/test_error_spread.py
@@ -13,11 +13,11 @@ def test_error_spread_score(backend):
     obs = np.random.randn(
         N,
     )
-    fcts = obs[:, None] + np.random.randn(N, ENSEMBLE_SIZE)
-    res = error_spread_score(fcts, obs, backend=backend)
+    fct = obs[:, None] + np.random.randn(N, ENSEMBLE_SIZE)
+    res = error_spread_score(obs, fct, backend=backend)
 
     # approx zero when perfect forecast
-    perfect_fcts = obs[..., None] + np.random.randn(N, ENSEMBLE_SIZE) * 1e-5
-    res = error_spread_score(perfect_fcts, obs, backend=backend)
+    perfect_fct = obs[..., None] + np.random.randn(N, ENSEMBLE_SIZE) * 1e-5
+    res = error_spread_score(obs, perfect_fct, backend=backend)
     res = np.asarray(res)
     assert not np.any(res - 0.0 > 0.0001)

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -10,5 +10,5 @@ N = 100
 
 @pytest.mark.parametrize("backend", BACKENDS)
 def test_normal(backend):
-    res = _logs.logs_normal(0.1, 0.1, 0.0, backend=backend)
+    res = _logs.logs_normal(0.0, 0.1, 0.1, backend=backend)
     assert np.isclose(res, -0.8836466, rtol=1e-5)

--- a/tests/test_variogram.py
+++ b/tests/test_variogram.py
@@ -13,9 +13,9 @@ N_VARS = 30
 @pytest.mark.parametrize("backend", BACKENDS)
 def test_variogram_score(backend):
     obs = np.random.randn(N, N_VARS)
-    fcts = np.expand_dims(obs, axis=-2) + np.random.randn(N, ENSEMBLE_SIZE, N_VARS)
+    fct = np.expand_dims(obs, axis=-2) + np.random.randn(N, ENSEMBLE_SIZE, N_VARS)
 
-    res = variogram_score(fcts, obs, backend=backend)
+    res = variogram_score(obs, fct, backend=backend)
 
     if backend in ["numpy", "numba"]:
         assert isinstance(res, np.ndarray)
@@ -26,9 +26,9 @@ def test_variogram_score(backend):
 @pytest.mark.parametrize("backend", BACKENDS)
 def test_variogram_score_permuted_dims(backend):
     obs = np.random.randn(N, N_VARS)
-    fcts = np.expand_dims(obs, axis=-2) + np.random.randn(N, ENSEMBLE_SIZE, N_VARS)
+    fct = np.expand_dims(obs, axis=-2) + np.random.randn(N, ENSEMBLE_SIZE, N_VARS)
 
-    res = variogram_score(fcts, obs, v_axis=-1, m_axis=-2, backend=backend)
+    res = variogram_score(obs, fct, v_axis=-1, m_axis=-2, backend=backend)
 
     if backend in ["numpy", "numba"]:
         assert isinstance(res, np.ndarray)
@@ -38,14 +38,14 @@ def test_variogram_score_permuted_dims(backend):
 
 @pytest.mark.parametrize("backend", BACKENDS)
 def test_variogram_score_correctness(backend):
-    fcts = np.array(
+    fct = np.array(
         [[0.79546742, 0.4777960, 0.2164079], [0.02461368, 0.7584595, 0.3181810]]
     )
 
     obs = np.array([0.2743836, 0.8146400])
 
-    res = variogram_score(fcts.T, obs, p=0.5, backend=backend)
+    res = variogram_score(obs, fct.T, p=0.5, backend=backend)
     np.testing.assert_allclose(res, 0.05083489, rtol=1e-5)
 
-    res = variogram_score(fcts.T, obs, p=1.0, backend=backend)
+    res = variogram_score(obs, fct.T, p=1.0, backend=backend)
     np.testing.assert_allclose(res, 0.04856365, rtol=1e-5)

--- a/tests/test_wcrps.py
+++ b/tests/test_wcrps.py
@@ -18,10 +18,10 @@ def test_twcrps_vs_crps(backend):
     obs = np.random.randn(N)
     mu = obs + np.random.randn(N) * 0.1
     sigma = abs(np.random.randn(N)) * 0.3
-    fcts = np.random.randn(N, ENSEMBLE_SIZE) * sigma[..., None] + mu[..., None]
+    fct = np.random.randn(N, ENSEMBLE_SIZE) * sigma[..., None] + mu[..., None]
 
-    res = crps_ensemble(fcts, obs, backend=backend, estimator="nrg")
-    resw = twcrps_ensemble(fcts, obs, lambda x: x, estimator="nrg", backend=backend)
+    res = crps_ensemble(obs, fct, backend=backend, estimator="nrg")
+    resw = twcrps_ensemble(obs, fct, lambda x: x, estimator="nrg", backend=backend)
     np.testing.assert_allclose(res, resw, rtol=1e-10)
 
 
@@ -30,10 +30,10 @@ def test_owcrps_vs_crps(backend):
     obs = np.random.randn(N)
     mu = obs + np.random.randn(N) * 0.1
     sigma = abs(np.random.randn(N)) * 0.5
-    fcts = np.random.randn(N, ENSEMBLE_SIZE) * sigma[..., None] + mu[..., None]
+    fct = np.random.randn(N, ENSEMBLE_SIZE) * sigma[..., None] + mu[..., None]
 
-    res = crps_ensemble(fcts, obs, backend=backend, estimator="nrg")
-    resw = owcrps_ensemble(fcts, obs, lambda x: x * 0.0 + 1.0, backend=backend)
+    res = crps_ensemble(obs, fct, backend=backend, estimator="nrg")
+    resw = owcrps_ensemble(obs, fct, lambda x: x * 0.0 + 1.0, backend=backend)
     np.testing.assert_allclose(res, resw, rtol=1e-5)
 
 
@@ -42,16 +42,16 @@ def test_vrcrps_vs_crps(backend):
     obs = np.random.randn(N)
     mu = obs + np.random.randn(N) * 0.1
     sigma = abs(np.random.randn(N)) * 0.3
-    fcts = np.random.randn(N, ENSEMBLE_SIZE) * sigma[..., None] + mu[..., None]
+    fct = np.random.randn(N, ENSEMBLE_SIZE) * sigma[..., None] + mu[..., None]
 
-    res = crps_ensemble(fcts, obs, backend=backend, estimator="nrg")
-    resw = vrcrps_ensemble(fcts, obs, lambda x: x * 0.0 + 1.0, backend=backend)
+    res = crps_ensemble(obs, fct, backend=backend, estimator="nrg")
+    resw = vrcrps_ensemble(obs, fct, lambda x: x * 0.0 + 1.0, backend=backend)
     np.testing.assert_allclose(res, resw, atol=1e-6)
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
 def test_owcrps_score_correctness(backend):
-    fcts = np.array(
+    fct = np.array(
         [
             [-0.03574194, 0.06873582, 0.03098684, 0.07316138, 0.08498165],
             [-0.11957874, 0.26472238, -0.06324622, 0.43026451, -0.25640457],
@@ -84,19 +84,19 @@ def test_owcrps_score_correctness(backend):
     def w_func(x):
         return (x > -1).astype(float)
 
-    res = np.mean(np.float64(owcrps_ensemble(fcts, obs, w_func, backend=backend)))
+    res = np.mean(np.float64(owcrps_ensemble(obs, fct, w_func, backend=backend)))
     np.testing.assert_allclose(res, 0.09320807, rtol=1e-6)
 
     def w_func(x):
         return (x < 1.85).astype(float)
 
-    res = np.mean(np.float64(owcrps_ensemble(fcts, obs, w_func, backend=backend)))
+    res = np.mean(np.float64(owcrps_ensemble(obs, fct, w_func, backend=backend)))
     np.testing.assert_allclose(res, 0.09933139, rtol=1e-6)
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
 def test_twcrps_score_correctness(backend):
-    fcts = np.array(
+    fct = np.array(
         [
             [-0.03574194, 0.06873582, 0.03098684, 0.07316138, 0.08498165],
             [-0.11957874, 0.26472238, -0.06324622, 0.43026451, -0.25640457],
@@ -130,7 +130,7 @@ def test_twcrps_score_correctness(backend):
         return np.maximum(x, -1.0)
 
     res = np.mean(
-        np.float64(twcrps_ensemble(fcts, obs, v_func, estimator="nrg", backend=backend))
+        np.float64(twcrps_ensemble(obs, fct, v_func, estimator="nrg", backend=backend))
     )
     np.testing.assert_allclose(res, 0.09489662, rtol=1e-6)
 
@@ -138,14 +138,14 @@ def test_twcrps_score_correctness(backend):
         return np.minimum(x, 1.85)
 
     res = np.mean(
-        np.float64(twcrps_ensemble(fcts, obs, v_func, estimator="nrg", backend=backend))
+        np.float64(twcrps_ensemble(obs, fct, v_func, estimator="nrg", backend=backend))
     )
     np.testing.assert_allclose(res, 0.0994809, rtol=1e-6)
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
 def test_vrcrps_score_correctness(backend):
-    fcts = np.array(
+    fct = np.array(
         [
             [-0.03574194, 0.06873582, 0.03098684, 0.07316138, 0.08498165],
             [-0.11957874, 0.26472238, -0.06324622, 0.43026451, -0.25640457],
@@ -178,11 +178,11 @@ def test_vrcrps_score_correctness(backend):
     def w_func(x):
         return (x > -1).astype(float)
 
-    res = np.mean(np.float64(vrcrps_ensemble(fcts, obs, w_func, backend=backend)))
+    res = np.mean(np.float64(vrcrps_ensemble(obs, fct, w_func, backend=backend)))
     np.testing.assert_allclose(res, 0.1003983, rtol=1e-6)
 
     def w_func(x):
         return (x < 1.85).astype(float)
 
-    res = np.mean(np.float64(vrcrps_ensemble(fcts, obs, w_func, backend=backend)))
+    res = np.mean(np.float64(vrcrps_ensemble(obs, fct, w_func, backend=backend)))
     np.testing.assert_allclose(res, 0.1950857, rtol=1e-6)

--- a/tests/test_wenergy.py
+++ b/tests/test_wenergy.py
@@ -18,12 +18,12 @@ N_VARS = 3
 @pytest.mark.parametrize("backend", BACKENDS)
 def test_owes_vs_es(backend):
     obs = np.random.randn(N, N_VARS)
-    fcts = np.expand_dims(obs, axis=-2) + np.random.randn(N, ENSEMBLE_SIZE, N_VARS)
+    fct = np.expand_dims(obs, axis=-2) + np.random.randn(N, ENSEMBLE_SIZE, N_VARS)
 
-    res = energy_score(fcts, obs, backend=backend)
+    res = energy_score(obs, fct, backend=backend)
     resw = owenergy_score(
-        fcts,
         obs,
+        fct,
         lambda x: backends[backend].mean(x) * 0.0 + 1.0,
         backend=backend,
     )
@@ -33,22 +33,22 @@ def test_owes_vs_es(backend):
 @pytest.mark.parametrize("backend", BACKENDS)
 def test_twes_vs_es(backend):
     obs = np.random.randn(N, N_VARS)
-    fcts = np.expand_dims(obs, axis=-2) + np.random.randn(N, ENSEMBLE_SIZE, N_VARS)
+    fct = np.expand_dims(obs, axis=-2) + np.random.randn(N, ENSEMBLE_SIZE, N_VARS)
 
-    res = energy_score(fcts, obs, backend=backend)
-    resw = twenergy_score(fcts, obs, lambda x: x, backend=backend)
+    res = energy_score(obs, fct, backend=backend)
+    resw = twenergy_score(obs, fct, lambda x: x, backend=backend)
     np.testing.assert_allclose(res, resw, rtol=1e-10)
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
 def test_vres_vs_es(backend):
     obs = np.random.randn(N, N_VARS)
-    fcts = np.expand_dims(obs, axis=-2) + np.random.randn(N, ENSEMBLE_SIZE, N_VARS)
+    fct = np.expand_dims(obs, axis=-2) + np.random.randn(N, ENSEMBLE_SIZE, N_VARS)
 
-    res = energy_score(fcts, obs, backend=backend)
+    res = energy_score(obs, fct, backend=backend)
     resw = vrenergy_score(
-        fcts,
         obs,
+        fct,
         lambda x: backends[backend].mean(x) * 0.0 + 1.0,
         backend=backend,
     )
@@ -57,7 +57,7 @@ def test_vres_vs_es(backend):
 
 @pytest.mark.parametrize("backend", BACKENDS)
 def test_owenergy_score_correctness(backend):
-    fcts = np.array(
+    fct = np.array(
         [[0.79546742, 0.4777960, 0.2164079], [0.02461368, 0.7584595, 0.3181810]]
     ).T
     obs = np.array([0.2743836, 0.8146400])
@@ -65,19 +65,19 @@ def test_owenergy_score_correctness(backend):
     def w_func(x):
         return backends[backend].all(x > 0.2)
 
-    res = owenergy_score(fcts, obs, w_func, backend=backend)
+    res = owenergy_score(obs, fct, w_func, backend=backend)
     np.testing.assert_allclose(res, 0.2274243, rtol=1e-6)
 
     def w_func(x):
         return backends[backend].all(x < 1.0)
 
-    res = owenergy_score(fcts, obs, w_func, backend=backend)
+    res = owenergy_score(obs, fct, w_func, backend=backend)
     np.testing.assert_allclose(res, 0.3345418, rtol=1e-6)
 
 
 # @pytest.mark.parametrize("backend", BACKENDS)
 # def test_twenergy_score_correctness(backend):
-#     fcts = np.array(
+#     fct = np.array(
 #         [[0.79546742, 0.4777960, 0.2164079], [0.02461368, 0.7584595, 0.3181810]]
 #     ).T
 #     obs = np.array([0.2743836, 0.8146400])
@@ -86,12 +86,12 @@ def test_owenergy_score_correctness(backend):
 #         return np.maximum(x, t)
 
 #     t = 0.2
-#     res = twenergy_score(fcts, obs, v_func, (t,), backend=backend)
+#     res = twenergy_score(obs, fct, v_func, (t,), backend=backend)
 #     np.testing.assert_allclose(res, 0.3116075, rtol=1e-6)
 
 #     def v_func(x, t):
 #         return np.minimum(x, t)
 
 #     t = 1
-#     res = twenergy_score(fcts, obs, v_func, (t,), backend=backend)
+#     res = twenergy_score(obs, fct, v_func, (t,), backend=backend)
 #     np.testing.assert_allclose(res, 0.3345418, rtol=1e-6)

--- a/tests/test_wvariogram.py
+++ b/tests/test_wvariogram.py
@@ -18,12 +18,12 @@ N_VARS = 3
 @pytest.mark.parametrize("backend", BACKENDS)
 def test_owvs_vs_vs(backend):
     obs = np.random.randn(N, N_VARS)
-    fcts = np.expand_dims(obs, axis=-2) + np.random.randn(N, ENSEMBLE_SIZE, N_VARS)
+    fct = np.expand_dims(obs, axis=-2) + np.random.randn(N, ENSEMBLE_SIZE, N_VARS)
 
-    res = variogram_score(fcts, obs, backend=backend)
+    res = variogram_score(obs, fct, backend=backend)
     resw = owvariogram_score(
-        fcts,
         obs,
+        fct,
         lambda x: backends[backend].mean(x) * 0.0 + 1.0,
         backend=backend,
     )
@@ -33,22 +33,22 @@ def test_owvs_vs_vs(backend):
 @pytest.mark.parametrize("backend", BACKENDS)
 def test_twvs_vs_vs(backend):
     obs = np.random.randn(N, N_VARS)
-    fcts = np.expand_dims(obs, axis=-2) + np.random.randn(N, ENSEMBLE_SIZE, N_VARS)
+    fct = np.expand_dims(obs, axis=-2) + np.random.randn(N, ENSEMBLE_SIZE, N_VARS)
 
-    res = variogram_score(fcts, obs, backend=backend)
-    resw = twvariogram_score(fcts, obs, lambda x: x, backend=backend)
+    res = variogram_score(obs, fct, backend=backend)
+    resw = twvariogram_score(obs, fct, lambda x: x, backend=backend)
     np.testing.assert_allclose(res, resw, rtol=5e-5)
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
 def test_vrvs_vs_vs(backend):
     obs = np.random.randn(N, N_VARS)
-    fcts = np.expand_dims(obs, axis=-2) + np.random.randn(N, ENSEMBLE_SIZE, N_VARS)
+    fct = np.expand_dims(obs, axis=-2) + np.random.randn(N, ENSEMBLE_SIZE, N_VARS)
 
-    res = variogram_score(fcts, obs, backend=backend)
+    res = variogram_score(obs, fct, backend=backend)
     resw = vrvariogram_score(
-        fcts,
         obs,
+        fct,
         lambda x: backends[backend].mean(x) * 0.0 + 1.0,
         backend=backend,
     )
@@ -57,7 +57,7 @@ def test_vrvs_vs_vs(backend):
 
 @pytest.mark.parametrize("backend", BACKENDS)
 def test_owvariogram_score_correctness(backend):
-    fcts = np.array(
+    fct = np.array(
         [[0.79546742, 0.4777960, 0.2164079], [0.02461368, 0.7584595, 0.3181810]]
     ).T
     obs = np.array([0.2743836, 0.8146400])
@@ -67,19 +67,19 @@ def test_owvariogram_score_correctness(backend):
             backends[backend].all(x > 0.2) + 0.0
         )  # + 0.0 works to convert to float in every backend
 
-    res = owvariogram_score(fcts, obs, w_func, p=0.5, backend=backend)
+    res = owvariogram_score(obs, fct, w_func, p=0.5, backend=backend)
     np.testing.assert_allclose(res, 0.1929739, rtol=1e-6)
 
     def w_func(x):
         return backends[backend].all(x < 1.0) + 0.0
 
-    res = owvariogram_score(fcts, obs, w_func, p=1.0, backend=backend)
+    res = owvariogram_score(obs, fct, w_func, p=1.0, backend=backend)
     np.testing.assert_allclose(res, 0.04856366, rtol=1e-6)
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
 def test_twvariogram_score_correctness(backend):
-    fcts = np.array(
+    fct = np.array(
         [[0.79546742, 0.4777960, 0.2164079], [0.02461368, 0.7584595, 0.3181810]]
     ).T
     obs = np.array([0.2743836, 0.8146400])
@@ -87,11 +87,11 @@ def test_twvariogram_score_correctness(backend):
     def v_func(x):
         return np.maximum(x, 0.2)
 
-    res = twvariogram_score(fcts, obs, v_func, p=0.5, backend=backend)
+    res = twvariogram_score(obs, fct, v_func, p=0.5, backend=backend)
     np.testing.assert_allclose(res, 0.07594679, rtol=1e-6)
 
     def v_func(x):
         return np.minimum(x, 1.0)
 
-    res = twvariogram_score(fcts, obs, v_func, p=1.0, backend=backend)
+    res = twvariogram_score(obs, fct, v_func, p=1.0, backend=backend)
     np.testing.assert_allclose(res, 0.04856366, rtol=1e-6)


### PR DESCRIPTION
This PR brings an important and **breaking** change. 

In all functions, the argument for the observed values is put first. This is consistent with other existing libraries (including R's scoringRules) and is a better design since the number of arguments for the observations is always one, whereas the number of arguments describing the forecasts can vary. Thus it makes sense to have observations first and then the rest. 