### PR TITLE
Brier score: Correct order of arguments in pass-through to core score function

### DIFF
--- a/scoringrules/_brier.py
+++ b/scoringrules/_brier.py
@@ -37,7 +37,7 @@ def brier_score(
         The computed Brier Score.
 
     """
-    return brier.brier_score(forecasts, observations, backend=backend)
+    return brier.brier_score(obs=observations, forecasts=forecasts, backend=backend)
 
 
 __all__ = ["brier_score"]


### PR DESCRIPTION
For the sake of correctness, but shouldn't have had any impact before.