### PR TITLE
Lazy compilation for numba gufuncs

### DIFF
--- a/scoringrules/core/crps/_gufuncs.py
+++ b/scoringrules/core/crps/_gufuncs.py
@@ -7,18 +7,11 @@ INV_SQRT_PI = 1 / np.sqrt(np.pi)
 EPSILON = 1e-6
 
 
-@guvectorize(
-    [
-        "void(float32[:], float32[:], float32[:], float32[:])",
-        "void(float64[:], float64[:], float64[:], float64[:])",
-    ],
-    "(),(a),(a)->()",
-)
+@guvectorize("(),(a),(a)->()")
 def quantile_pinball_gufunc(
     obs: np.ndarray, fct: np.ndarray, alpha: np.ndarray, out: np.ndarray
 ):
     """Pinball loss based estimator for the CRPS from quantiles."""
-    obs = obs[0]
     Q = fct.shape[0]
     pb = 0
     for fc, level in zip(fct, alpha):  # noqa: B905
@@ -26,16 +19,9 @@ def quantile_pinball_gufunc(
     out[0] = 2 * (pb / Q)
 
 
-@guvectorize(
-    [
-        "void(float32[:], float32[:], float32[:])",
-        "void(float64[:], float64[:], float64[:])",
-    ],
-    "(),(n)->()",
-)
+@guvectorize("(),(n)->()")
 def _crps_ensemble_int_gufunc(obs: np.ndarray, fct: np.ndarray, out: np.ndarray):
     """CRPS estimator based on the integral form."""
-    obs = obs[0]
     M = fct.shape[0]
 
     if np.isnan(obs):
@@ -71,16 +57,9 @@ def _crps_ensemble_int_gufunc(obs: np.ndarray, fct: np.ndarray, out: np.ndarray)
     out[0] = integral
 
 
-@guvectorize(
-    [
-        "void(float32[:], float32[:], float32[:])",
-        "void(float64[:], float64[:], float64[:])",
-    ],
-    "(),(n)->()",
-)
+@guvectorize("(),(n)->()")
 def _crps_ensemble_qd_gufunc(obs: np.ndarray, fct: np.ndarray, out: np.ndarray):
     """CRPS estimator based on the quantile decomposition form."""
-    obs = obs[0]
     M = fct.shape[-1]
 
     if np.isnan(obs):
@@ -99,16 +78,9 @@ def _crps_ensemble_qd_gufunc(obs: np.ndarray, fct: np.ndarray, out: np.ndarray):
     out[0] = (2 / M**2) * integral
 
 
-@guvectorize(
-    [
-        "void(float32[:], float32[:], float32[:])",
-        "void(float64[:], float64[:], float64[:])",
-    ],
-    "(),(n)->()",
-)
+@guvectorize("(),(n)->()")
 def _crps_ensemble_nrg_gufunc(obs: np.ndarray, fct: np.ndarray, out: np.ndarray):
     """CRPS estimator based on the energy form."""
-    obs = obs[0]
     M = fct.shape[-1]
 
     if np.isnan(obs):
@@ -153,16 +125,10 @@ def _crps_ensemble_fair_gufunc(obs: np.ndarray, fct: np.ndarray, out: np.ndarray
     out[0] = e_1 / M - 0.5 * e_2 / (M * (M - 1))
 
 
-@guvectorize(
-    [
-        "void(float32[:], float32[:], float32[:])",
-        "void(float64[:], float64[:], float64[:])",
-    ],
-    "(),(n)->()",
-)
+@guvectorize("(),(n)->()")
 def _crps_ensemble_pwm_gufunc(obs: np.ndarray, fct: np.ndarray, out: np.ndarray):
     """CRPS estimator based on the probability weighted moment (PWM) form."""
-    obs = obs[0]
+    # obs = obs[0]
     M = fct.shape[-1]
 
     if np.isnan(obs):
@@ -181,19 +147,12 @@ def _crps_ensemble_pwm_gufunc(obs: np.ndarray, fct: np.ndarray, out: np.ndarray)
     out[0] = expected_diff / M + β_0 / M - 2 * β_1 / (M * (M - 1))
 
 
-@guvectorize(
-    [
-        "void(float32[:], float32[:], float32[:])",
-        "void(float64[:], float64[:], float64[:])",
-    ],
-    "(),(n)->()",
-)
+@guvectorize("(),(n)->()")
 def _crps_ensemble_akr_gufunc(obs: np.ndarray, fct: np.ndarray, out: np.ndarray):
     """CRPS estimaton based on the approximate kernel representation."""
     M = fct.shape[-1]
-    obs = obs[0]
-    e_1 = 0
-    e_2 = 0
+    e_1 = 0.0
+    e_2 = 0.0
     for i, forecast in enumerate(fct):
         if i == 0:
             i = M - 1
@@ -202,19 +161,13 @@ def _crps_ensemble_akr_gufunc(obs: np.ndarray, fct: np.ndarray, out: np.ndarray)
     out[0] = e_1 / M - 0.5 * 1 / M * e_2
 
 
-@guvectorize(
-    [
-        "void(float32[:], float32[:], float32[:])",
-        "void(float64[:], float64[:], float64[:])",
-    ],
-    "(),(n)->()",
-)
+@guvectorize("(),(n)->()")
 def _crps_ensemble_akr_circperm_gufunc(
     obs: np.ndarray, fct: np.ndarray, out: np.ndarray
 ):
     """CRPS estimaton based on the AKR with cyclic permutation."""
     M = fct.shape[-1]
-    obs = obs[0]
+    # obs = obs[0]
     e_1 = 0.0
     e_2 = 0.0
     for i, forecast in enumerate(fct):
@@ -224,13 +177,7 @@ def _crps_ensemble_akr_circperm_gufunc(
     out[0] = e_1 / M - 0.5 * 1 / M * e_2
 
 
-@guvectorize(
-    [
-        "void(float32[:], float32[:], float32[:], float32[:], float32[:])",
-        "void(float64[:], float64[:], float64[:], float64[:], float64[:])",
-    ],
-    "(),(n),(),(n)->()",
-)
+@guvectorize("(),(n),(),(n)->()")
 def _owcrps_ensemble_nrg_gufunc(
     obs: np.ndarray,
     fct: np.ndarray,
@@ -239,8 +186,8 @@ def _owcrps_ensemble_nrg_gufunc(
     out: np.ndarray,
 ):
     """Outcome-weighted CRPS estimator based on the energy form."""
-    obs = obs[0]
-    ow = ow[0]
+    # obs = obs[0]
+    # ow = ow[0]
     M = fct.shape[-1]
 
     if np.isnan(obs):
@@ -260,13 +207,7 @@ def _owcrps_ensemble_nrg_gufunc(
     out[0] = e_1 / (M * wbar) - 0.5 * e_2 / ((M * wbar) ** 2)
 
 
-@guvectorize(
-    [
-        "void(float32[:], float32[:], float32[:], float32[:], float32[:])",
-        "void(float64[:], float64[:], float64[:], float64[:], float64[:])",
-    ],
-    "(),(n),(),(n)->()",
-)
+@guvectorize("(),(n),(),(n)->()")
 def _vrcrps_ensemble_nrg_gufunc(
     obs: np.ndarray,
     fct: np.ndarray,
@@ -275,8 +216,8 @@ def _vrcrps_ensemble_nrg_gufunc(
     out: np.ndarray,
 ):
     """Vertically re-scaled CRPS estimator based on the energy form."""
-    obs = obs[0]
-    ow = ow[0]
+    # obs = obs[0]
+    # ow = ow[0]
     M = fct.shape[-1]
 
     if np.isnan(obs):
@@ -343,16 +284,29 @@ def _crps_logistic_ufunc(obs: float, mu: float, sigma: float) -> float:
     return out
 
 
+def _lazy_gufunc_wrapper(func):
+    """Wrapper for lazy gufuncs so they return a value instead of having to take in an output array."""
+    """This is a workaround for lazy gufuncs that do not return an output array."""
+
+    def wrapper(*args):
+        out = np.empty_like(args[0])
+        # breakpoint()
+        func(*args, out)
+        return out
+
+    return wrapper
+
+
 estimator_gufuncs = {
-    "akr_circperm": _crps_ensemble_akr_circperm_gufunc,
-    "akr": _crps_ensemble_akr_gufunc,
+    "akr_circperm": _lazy_gufunc_wrapper(_crps_ensemble_akr_circperm_gufunc),
+    "akr": _lazy_gufunc_wrapper(_crps_ensemble_akr_gufunc),
     "fair": _crps_ensemble_fair_gufunc,
-    "int": _crps_ensemble_int_gufunc,
-    "nrg": _crps_ensemble_nrg_gufunc,
-    "pwm": _crps_ensemble_pwm_gufunc,
-    "qd": _crps_ensemble_qd_gufunc,
-    "ownrg": _owcrps_ensemble_nrg_gufunc,
-    "vrnrg": _vrcrps_ensemble_nrg_gufunc,
+    "int": _lazy_gufunc_wrapper(_crps_ensemble_int_gufunc),
+    "nrg": _lazy_gufunc_wrapper(_crps_ensemble_nrg_gufunc),
+    "pwm": _lazy_gufunc_wrapper(_crps_ensemble_pwm_gufunc),
+    "qd": _lazy_gufunc_wrapper(_crps_ensemble_qd_gufunc),
+    "ownrg": _lazy_gufunc_wrapper(_owcrps_ensemble_nrg_gufunc),
+    "vrnrg": _lazy_gufunc_wrapper(_vrcrps_ensemble_nrg_gufunc),
 }
 
 __all__ = [

--- a/scoringrules/core/crps/_gufuncs.py
+++ b/scoringrules/core/crps/_gufuncs.py
@@ -60,9 +60,16 @@ def _crps_ensemble_int_gufunc(obs: np.ndarray, fct: np.ndarray, out: np.ndarray)
     out[0] = integral
 
 
-@guvectorize("(),(n)->()")
+@guvectorize(
+    [
+        "void(float32[:], float32[:], float32[:])",
+        "void(float64[:], float64[:], float64[:])",
+    ],
+    "(),(n)->()",
+)
 def _crps_ensemble_qd_gufunc(obs: np.ndarray, fct: np.ndarray, out: np.ndarray):
     """CRPS estimator based on the quantile decomposition form."""
+    obs = obs[0]
     M = fct.shape[-1]
 
     if np.isnan(obs):
@@ -295,7 +302,7 @@ estimator_gufuncs = {
     "int": lazy_gufunc_wrapper_uv(_crps_ensemble_int_gufunc),
     "nrg": lazy_gufunc_wrapper_uv(_crps_ensemble_nrg_gufunc),
     "pwm": lazy_gufunc_wrapper_uv(_crps_ensemble_pwm_gufunc),
-    "qd": lazy_gufunc_wrapper_uv(_crps_ensemble_qd_gufunc),
+    "qd": _crps_ensemble_qd_gufunc,
     "ownrg": lazy_gufunc_wrapper_uv(_owcrps_ensemble_nrg_gufunc),
     "vrnrg": lazy_gufunc_wrapper_uv(_vrcrps_ensemble_nrg_gufunc),
 }

--- a/scoringrules/core/energy/_gufuncs.py
+++ b/scoringrules/core/energy/_gufuncs.py
@@ -1,6 +1,8 @@
 import numpy as np
 from numba import guvectorize
 
+from scoringrules.core.utils import lazy_gufunc_wrapper_mv
+
 
 @guvectorize(
     [
@@ -8,6 +10,7 @@ from numba import guvectorize
         "void(float64[:], float64[:,:], float64[:])",
     ],
     "(d),(m,d)->()",
+    cache=True,
 )
 def _energy_score_gufunc(
     obs: np.ndarray,
@@ -27,13 +30,8 @@ def _energy_score_gufunc(
     out[0] = e_1 / M - 0.5 / (M**2) * e_2
 
 
-@guvectorize(
-    [
-        "void(float32[:], float32[:,:], float32[:], float32[:], float32[:])",
-        "void(float64[:], float64[:,:], float64[:], float64[:], float64[:])",
-    ],
-    "(d),(m,d),(),(m)->()",
-)
+@lazy_gufunc_wrapper_mv
+@guvectorize("(d),(m,d),(),(m)->()")
 def _owenergy_score_gufunc(
     obs: np.ndarray,
     fct: np.ndarray,
@@ -43,7 +41,6 @@ def _owenergy_score_gufunc(
 ):
     """Compute the Outcome-Weighted Energy Score for a finite ensemble."""
     M = fct.shape[0]
-    ow = ow[0]
 
     e_1 = 0.0
     e_2 = 0.0
@@ -57,13 +54,8 @@ def _owenergy_score_gufunc(
     out[0] = e_1 / (M * wbar) - 0.5 * e_2 / (M**2 * wbar**2)
 
 
-@guvectorize(
-    [
-        "void(float32[:], float32[:,:], float32[:], float32[:], float32[:])",
-        "void(float64[:], float64[:,:], float64[:], float64[:], float64[:])",
-    ],
-    "(d),(m,d),(),(m)->()",
-)
+@lazy_gufunc_wrapper_mv
+@guvectorize("(d),(m,d),(),(m)->()")
 def _vrenergy_score_gufunc(
     obs: np.ndarray,
     fct: np.ndarray,
@@ -73,7 +65,6 @@ def _vrenergy_score_gufunc(
 ):
     """Compute the Vertically Re-scaled Energy Score for a finite ensemble."""
     M = fct.shape[0]
-    ow = ow[0]
 
     e_1 = 0.0
     e_2 = 0.0

--- a/scoringrules/core/error_spread/_gufunc.py
+++ b/scoringrules/core/error_spread/_gufunc.py
@@ -1,17 +1,11 @@
 import numpy as np
 from numba import guvectorize
 
-INV_SQRT_PI = 1 / np.sqrt(np.pi)
-EPSILON = 1e-6
+from scoringrules.core.utils import lazy_gufunc_wrapper_uv
 
 
-@guvectorize(
-    [
-        "void(float32[:], float32[:], float32[:])",
-        "void(float64[:], float64[:], float64[:])",
-    ],
-    "(),(n)->()",
-)
+@lazy_gufunc_wrapper_uv
+@guvectorize("(),(n)->()")
 def _error_spread_score_gufunc(obs: np.ndarray, fct: np.ndarray, out: np.ndarray):
     """Error spread score."""
     M = fct.shape[0]
@@ -34,7 +28,7 @@ def _error_spread_score_gufunc(obs: np.ndarray, fct: np.ndarray, out: np.ndarray
     g /= (M - 1) * (M - 2)
 
     for i in range(M):
-        e += fct[i] - obs[i]
+        e += fct[i] - obs
     e /= M
 
     out[0] = (s**2 - e**2 - e * s * g) ** 2

--- a/scoringrules/core/utils.py
+++ b/scoringrules/core/utils.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from scoringrules.backend import backends
 
 _V_AXIS = -1
@@ -30,3 +32,36 @@ def multivariate_array_check(obs, fct, m_axis, v_axis, backend=None):
     v_axis = v_axis if v_axis >= 0 else fct.ndim + v_axis
     _multivariate_shape_compatibility(obs, fct, m_axis)
     return _multivariate_shape_permute(obs, fct, m_axis, v_axis, backend=backend)
+
+
+def lazy_gufunc_wrapper_uv(func):
+    """
+    Wrapper for lazy/dynamic generalized universal functions so
+    they return a value instead of modifying an output array in-place.
+    This is the univariate version, which assumes that the shape of the
+    return value is the same as the first input argument (the observations).
+    """
+
+    def wrapper(*args):
+        out = np.empty_like(args[0])
+        func(*args, out)
+        return out
+
+    return wrapper
+
+
+def lazy_gufunc_wrapper_mv(func):
+    """
+    Wrapper for lazy/dynamic generalized universal functions so
+    they return a value instead of modifying an output array in-place.
+    This is the multivariate version, which assumes that the shape of the
+    return value is reduced to the shape of the first input argument
+    (the observations) along the last axis.
+    """
+
+    def wrapper(*args):
+        out = np.empty_like(args[0][..., 0])
+        func(*args, out)
+        return out
+
+    return wrapper

--- a/scoringrules/core/variogram/_gufuncs.py
+++ b/scoringrules/core/variogram/_gufuncs.py
@@ -1,6 +1,8 @@
 import numpy as np
 from numba import guvectorize
 
+from scoringrules.core.utils import lazy_gufunc_wrapper_mv
+
 
 @guvectorize(
     [
@@ -23,13 +25,8 @@ def _variogram_score_gufunc(obs, fct, p, out):
             out[0] += (vobs - vfct) ** 2
 
 
-@guvectorize(
-    [
-        "void(float32[:], float32[:,:], float32, float32, float32[:], float32[:])",
-        "void(float64[:], float64[:,:], float64, float64, float64[:], float64[:])",
-    ],
-    "(d),(m,d),(),(),(m)->()",
-)
+@lazy_gufunc_wrapper_mv
+@guvectorize("(d),(m,d),(),(),(m)->()")
 def _owvariogram_score_gufunc(obs, fct, p, ow, fw, out):
     M = fct.shape[-2]
     D = fct.shape[-1]
@@ -54,13 +51,8 @@ def _owvariogram_score_gufunc(obs, fct, p, ow, fw, out):
     out[0] = e_1 / (M * wbar) - 0.5 * e_2 / (M**2 * wbar**2)
 
 
-@guvectorize(
-    [
-        "void(float32[:], float32[:,:], float32, float32, float32[:], float32[:])",
-        "void(float64[:], float64[:,:], float64, float64, float64[:], float64[:])",
-    ],
-    "(d),(m,d),(),(),(m)->()",
-)
+@lazy_gufunc_wrapper_mv
+@guvectorize("(d),(m,d),(),(),(m)->()")
 def _vrvariogram_score_gufunc(obs, fct, p, ow, fw, out):
     M = fct.shape[-2]
     D = fct.shape[-1]

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -1,4 +1,3 @@
-import jax
 import numpy as np
 import pytest
 import scoringrules as sr
@@ -74,7 +73,7 @@ def test_gksmv(estimator, backend):
     if backend in ["numpy", "numba"]:
         assert isinstance(res, np.ndarray)
     elif backend == "jax":
-        assert isinstance(res, jax.Array)
+        assert "jax" in res.__module__
 
     if estimator == "nrg":
         # approx zero when perfect forecast

--- a/tests/test_variogram.py
+++ b/tests/test_variogram.py
@@ -1,4 +1,3 @@
-import jax
 import numpy as np
 import pytest
 
@@ -21,7 +20,7 @@ def test_variogram_score(backend):
     if backend in ["numpy", "numba"]:
         assert isinstance(res, np.ndarray)
     elif backend == "jax":
-        assert isinstance(res, jax.Array)
+        assert "jax" in res.__module__
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
@@ -34,7 +33,7 @@ def test_variogram_score_permuted_dims(backend):
     if backend in ["numpy", "numba"]:
         assert isinstance(res, np.ndarray)
     elif backend == "jax":
-        assert isinstance(res, jax.Array)
+        assert "jax" in res.__module__
 
 
 @pytest.mark.parametrize("backend", BACKENDS)


### PR DESCRIPTION
Refactors numba gufuncs to be lazily/dynamically compiled, with the exception of a few common functions which will still be compiled eagerly during import. This brings a significant improvement in terms of import time: on my (fairly slow) machine, it goes from 19s to 3s. Closes #80. 