### PR TITLE
Dawid-Sebastiani score

### DIFF
--- a/scoringrules/__init__.py
+++ b/scoringrules/__init__.py
@@ -51,7 +51,7 @@ from scoringrules._energy import (
     twes_ensemble,
     vres_ensemble,
 )
-from scoringrules._dss import dss_ensemble
+from scoringrules._dss import dssuv_ensemble, dssmv_ensemble
 from scoringrules._error_spread import error_spread_score
 from scoringrules._interval import interval_score, weighted_interval_score
 from scoringrules._logs import (
@@ -197,7 +197,8 @@ __all__ = [
     "rps_score",
     "log_score",
     "rls_score",
-    "dss_ensemble",
+    "dssuv_ensemble",
+    "dssmv_ensemble",
     "error_spread_score",
     "es_ensemble",
     "owes_ensemble",

--- a/scoringrules/__init__.py
+++ b/scoringrules/__init__.py
@@ -51,7 +51,7 @@ from scoringrules._energy import (
     twes_ensemble,
     vres_ensemble,
 )
-from scoringrules._dawid_sebastiani import dawid_sebastiani_score
+from scoringrules._dss import dss_ensemble
 from scoringrules._error_spread import error_spread_score
 from scoringrules._interval import interval_score, weighted_interval_score
 from scoringrules._logs import (
@@ -164,7 +164,6 @@ __all__ = [
     "crps_quantile",
     "crps_t",
     "crps_uniform",
-    "dawid_sebastiani_score",
     "owcrps_ensemble",
     "twcrps_ensemble",
     "vrcrps_ensemble",
@@ -198,6 +197,7 @@ __all__ = [
     "rps_score",
     "log_score",
     "rls_score",
+    "dss_ensemble",
     "error_spread_score",
     "es_ensemble",
     "owes_ensemble",

--- a/scoringrules/_dss.py
+++ b/scoringrules/_dss.py
@@ -100,7 +100,6 @@ def dssmv_ensemble(
     score: Array
         The computed Dawid-Sebastiani Score.
     """
-    backend = backend if backend is not None else backends._active
     obs, fct = multivariate_array_check(obs, fct, m_axis, v_axis, backend=backend)
 
     if backend == "numba":

--- a/scoringrules/_dss.py
+++ b/scoringrules/_dss.py
@@ -1,5 +1,6 @@
 import typing as tp
 
+from scoringrules.backend import backends
 from scoringrules.core import dss
 from scoringrules.core.utils import multivariate_array_check
 
@@ -7,13 +8,14 @@ if tp.TYPE_CHECKING:
     from scoringrules.core.typing import Array, Backend
 
 
-def dawid_sebastiani_score(
-    observations: "Array",
-    forecasts: "Array",
+def dss_ensemble(
+    obs: "Array",
+    fct: "Array",
     /,
     m_axis: int = -2,
     v_axis: int = -1,
     *,
+    bias: bool = False,
     backend: "Backend" = None,
 ) -> "Array":
     r"""Compute the Dawid-Sebastiani-Score for a finite multivariate ensemble.
@@ -22,16 +24,16 @@ def dawid_sebastiani_score(
 
     Parameters
     ----------
-    forecasts: Array
+    obs : array_like
+        The observed values, where the variables dimension is by default the last axis.
+    fct : array_like
         The predicted forecast ensemble, where the ensemble dimension is by default
         represented by the second last axis and the variables dimension by the last axis.
-    observations: Array
-        The observed values, where the variables dimension is by default the last axis.
-    m_axis: int
+    m_axis : int
         The axis corresponding to the ensemble dimension. Defaults to -2.
-    v_axis: int
+    v_axis : int or tuple of int
         The axis corresponding to the variables dimension. Defaults to -1.
-    backend: str
+    backend : str
         The name of the backend used for computations. Defaults to 'numba' if available, else 'numpy'.
 
     Returns
@@ -39,11 +41,10 @@ def dawid_sebastiani_score(
     ds_score: Array
         The computed Dawid-Sebastiani-Score.
     """
-    observations, forecasts = multivariate_array_check(
-        observations, forecasts, m_axis, v_axis, backend=backend
-    )
+    backend = backend if backend is not None else backends._active
+    obs, fct = multivariate_array_check(obs, fct, m_axis, v_axis, backend=backend)
 
     if backend == "numba":
-        return dss._dss_gufunc(observations, forecasts)
+        return dss._dss_gufunc(obs, fct, bias)
 
-    return dss._dss(observations, forecasts, backend=backend)
+    return dss.dss(obs, fct, bias, backend=backend)

--- a/scoringrules/_dss.py
+++ b/scoringrules/_dss.py
@@ -12,7 +12,7 @@ def dssuv_ensemble(
     obs: "Array",
     fct: "Array",
     /,
-    m_axis: int = -2,
+    m_axis: int = -1,
     *,
     bias: bool = False,
     backend: "Backend" = None,

--- a/scoringrules/_dss.py
+++ b/scoringrules/_dss.py
@@ -20,7 +20,7 @@ def dss_ensemble(
 ) -> "Array":
     r"""Compute the Dawid-Sebastiani-Score for a finite multivariate ensemble.
 
-    ## TO-DO ##
+
 
     Parameters
     ----------

--- a/scoringrules/_dss.py
+++ b/scoringrules/_dss.py
@@ -20,7 +20,13 @@ def dss_ensemble(
 ) -> "Array":
     r"""Compute the Dawid-Sebastiani-Score for a finite multivariate ensemble.
 
+    The Dawid-Sebastiani Score for an ensemble forecast is defined as
 
+    .. math::
+        \text{DSS}(F_{ens}, \mathbf{y})= (\mathbf{y} - \bar{mathbf{x}})^{\top} \Sigma^-1 (\mathbf{y} - \bar{mathbf{x}}) + \log \det(\Sigma)
+
+    where :math:`\bar{mathbf{x}}` is the mean of the ensemble members (along each dimension),
+    and :math:`\Sigma` is the sample covariance matrix estimated from the ensemble members.
 
     Parameters
     ----------
@@ -33,13 +39,16 @@ def dss_ensemble(
         The axis corresponding to the ensemble dimension. Defaults to -2.
     v_axis : int or tuple of int
         The axis corresponding to the variables dimension. Defaults to -1.
+    bias : bool
+        Logical specifying whether the biased or unbiased estimator of the covariance matrix
+        should be used to calculate the score. Default is the unbiased estimator (`bias=False`).
     backend : str
         The name of the backend used for computations. Defaults to 'numba' if available, else 'numpy'.
 
     Returns
     -------
-    ds_score: Array
-        The computed Dawid-Sebastiani-Score.
+    score: Array
+        The computed Dawid-Sebastiani Score.
     """
     backend = backend if backend is not None else backends._active
     obs, fct = multivariate_array_check(obs, fct, m_axis, v_axis, backend=backend)

--- a/scoringrules/backend/base.py
+++ b/scoringrules/backend/base.py
@@ -50,6 +50,7 @@ class ArrayBackend(abc.ABC):
         /,
         *,
         axis: int | tuple[int, ...] | None = None,
+        bias: bool = False,
         keepdims: bool = False,
     ) -> "Array":
         """Calculate the standard deviation of the input array ``x``."""

--- a/scoringrules/backend/base.py
+++ b/scoringrules/backend/base.py
@@ -297,3 +297,15 @@ class ArrayBackend(abc.ABC):
     @abc.abstractmethod
     def indices(self, x: "Array") -> int:
         """Return an array representing the indices of a grid."""
+
+    @abc.abstractmethod
+    def inv(self, x: "Array") -> "Array":
+        """Return the inverse of a matrix."""
+
+    @abc.abstractmethod
+    def cov(self, x: "Array", rowvar: bool, bias: bool) -> "Array":
+        """Return the covariance matrix from a sample."""
+
+    @abc.abstractmethod
+    def det(self, x: "Array") -> "Array":
+        """Return the determinant of a matrix."""

--- a/scoringrules/backend/base.py
+++ b/scoringrules/backend/base.py
@@ -310,3 +310,7 @@ class ArrayBackend(abc.ABC):
     @abc.abstractmethod
     def det(self, x: "Array") -> "Array":
         """Return the determinant of a matrix."""
+
+    @abc.abstractmethod
+    def reshape(self, x: "Array", shape: int | tuple[int, ...]) -> "Array":
+        """Reshape an array to a new ``shape``."""

--- a/scoringrules/backend/jax.py
+++ b/scoringrules/backend/jax.py
@@ -275,7 +275,7 @@ class JaxBackend(ArrayBackend):
         return jnp.linalg.inv(x)
 
     def cov(self, x: "Array", rowvar: bool = True, bias: bool = False) -> "Array":
-        return jnp.cov(x, rowavar=rowvar, bias=bias)
+        return jnp.cov(x, rowvar=rowvar, bias=bias)
 
     def det(self, x: "Array") -> "Array":
         return jnp.linalg.det(x)

--- a/scoringrules/backend/jax.py
+++ b/scoringrules/backend/jax.py
@@ -53,9 +53,11 @@ class JaxBackend(ArrayBackend):
         /,
         *,
         axis: int | tuple[int, ...] | None = None,
+        bias: bool = False,
         keepdims: bool = False,
     ) -> "Array":
-        return jnp.std(x, ddof=1, axis=axis, keepdims=keepdims)
+        ddof = 0 if bias else 1
+        return jnp.std(x, ddof=ddof, axis=axis, keepdims=keepdims)
 
     def quantile(
         self,

--- a/scoringrules/backend/jax.py
+++ b/scoringrules/backend/jax.py
@@ -269,6 +269,15 @@ class JaxBackend(ArrayBackend):
     def indices(self, dimensions: tuple) -> "Array":
         return jnp.indices(dimensions)
 
+    def inv(self, x: "Array") -> "Array":
+        return jnp.linalg.inv(x)
+
+    def cov(self, x: "Array", rowvar: bool = True, bias: bool = False) -> "Array":
+        return jnp.cov(x, rowavar=rowvar, bias=bias)
+
+    def det(self, x: "Array") -> "Array":
+        return jnp.linalg.det(x)
+
 
 if __name__ == "__main__":
     B = JaxBackend()

--- a/scoringrules/backend/jax.py
+++ b/scoringrules/backend/jax.py
@@ -280,6 +280,9 @@ class JaxBackend(ArrayBackend):
     def det(self, x: "Array") -> "Array":
         return jnp.linalg.det(x)
 
+    def reshape(self, x: "Array", shape: int | tuple[int, ...]) -> "Array":
+        return jnp.reshape(x, shape)
+
 
 if __name__ == "__main__":
     B = JaxBackend()

--- a/scoringrules/backend/numpy.py
+++ b/scoringrules/backend/numpy.py
@@ -53,9 +53,11 @@ class NumpyBackend(ArrayBackend):
         /,
         *,
         axis: int | tuple[int, ...] | None = None,
+        bias: bool = False,
         keepdims: bool = False,
     ) -> "NDArray":
-        return np.std(x, ddof=1, axis=axis, keepdims=keepdims)
+        ddof = 0 if bias else 1
+        return np.std(x, ddof=ddof, axis=axis, keepdims=keepdims)
 
     def quantile(
         self,

--- a/scoringrules/backend/numpy.py
+++ b/scoringrules/backend/numpy.py
@@ -276,6 +276,9 @@ class NumpyBackend(ArrayBackend):
     def det(self, x: "NDArray") -> "NDArray":
         return np.linalg.det(x)
 
+    def reshape(self, x: "NDArray", shape: int | tuple[int, ...]) -> "NDArray":
+        return np.reshape(x, shape=shape)
+
 
 class NumbaBackend(NumpyBackend):
     """Numba backend."""

--- a/scoringrules/backend/numpy.py
+++ b/scoringrules/backend/numpy.py
@@ -277,7 +277,7 @@ class NumpyBackend(ArrayBackend):
         return np.linalg.det(x)
 
     def reshape(self, x: "NDArray", shape: int | tuple[int, ...]) -> "NDArray":
-        return np.reshape(x, shape=shape)
+        return np.reshape(x, shape)
 
 
 class NumbaBackend(NumpyBackend):

--- a/scoringrules/backend/numpy.py
+++ b/scoringrules/backend/numpy.py
@@ -268,12 +268,8 @@ class NumpyBackend(ArrayBackend):
     def inv(self, x: "NDArray") -> "NDArray":
         return np.linalg.inv(x)
 
-    def cov(self, x: "NDArray") -> "NDArray":
-        if len(x.shape) == 2:
-            return np.cov(x)
-        else:
-            centered = x - x.mean(axis=-2, keepdims=True)
-            return (centered.transpose(0, 2, 1) @ centered) / (x.shape[-2] - 1)
+    def cov(self, x: "NDArray", rowvar: bool = True, bias: bool = False) -> "NDArray":
+        return np.cov(x, rowvar=rowvar, bias=bias)
 
     def det(self, x: "NDArray") -> "NDArray":
         return np.linalg.det(x)

--- a/scoringrules/backend/tensorflow.py
+++ b/scoringrules/backend/tensorflow.py
@@ -58,10 +58,12 @@ class TensorflowBackend(ArrayBackend):
         /,
         *,
         axis: int | tuple[int, ...] | None = None,
+        bias: bool = False,
         keepdims: bool = False,
     ) -> "Tensor":
         n = x.shape.num_elements() if axis is None else x.shape[axis]
-        resc = self.sqrt(n / (n - 1))
+        if not bias:
+            resc = self.sqrt(n / (n - 1))
         return tf.math.reduce_std(x, axis=axis, keepdims=keepdims) * resc
 
     def quantile(

--- a/scoringrules/backend/tensorflow.py
+++ b/scoringrules/backend/tensorflow.py
@@ -304,6 +304,21 @@ class TensorflowBackend(ArrayBackend):
         indices = tf.stack(index_grids)
         return indices
 
+    def inv(self, x: "Tensor") -> "Tensor":
+        return tf.linalg.inv(x)
+
+    def cov(self, x: "Tensor", rowvar: bool = True, bias: bool = False) -> "Tensor":
+        if not rowvar:
+            x = tf.transpose(x)
+        x = x - tf.reduce_mean(x, axis=1, keepdims=True)
+        correction = tf.cast(tf.shape(x)[1], x.dtype) - 1.0
+        if bias:
+            correction += 1.0
+        return tf.matmul(x, x, transpose_b=True) / correction
+
+    def det(self, x: "Tensor") -> "Tensor":
+        return tf.linalg.det(x)
+
 
 if __name__ == "__main__":
     B = TensorflowBackend()

--- a/scoringrules/backend/tensorflow.py
+++ b/scoringrules/backend/tensorflow.py
@@ -321,6 +321,9 @@ class TensorflowBackend(ArrayBackend):
     def det(self, x: "Tensor") -> "Tensor":
         return tf.linalg.det(x)
 
+    def reshape(self, x: "Tensor", shape: int | tuple[int, ...]) -> "Tensor":
+        return tf.reshape(x, shape)
+
 
 if __name__ == "__main__":
     B = TensorflowBackend()

--- a/scoringrules/backend/torch.py
+++ b/scoringrules/backend/torch.py
@@ -300,3 +300,6 @@ class TorchBackend(ArrayBackend):
 
     def det(self, x: "Tensor") -> "Tensor":
         return torch.linalg.det(x)
+
+    def reshape(self, x: "Tensor", shape: int | tuple[int, ...]) -> "Tensor":
+        return torch.reshape(x, shape)

--- a/scoringrules/backend/torch.py
+++ b/scoringrules/backend/torch.py
@@ -54,9 +54,11 @@ class TorchBackend(ArrayBackend):
         /,
         *,
         axis: int | tuple[int, ...] | None = None,
+        bias: bool = False,
         keepdims: bool = False,
     ) -> "Tensor":
-        return torch.std(x, correction=1, axis=axis, keepdim=keepdims)
+        correction = 0 if bias else 1
+        return torch.std(x, correction=correction, axis=axis, keepdim=keepdims)
 
     def quantile(
         self,

--- a/scoringrules/backend/torch.py
+++ b/scoringrules/backend/torch.py
@@ -292,7 +292,9 @@ class TorchBackend(ArrayBackend):
 
     def cov(self, x: "Tensor", rowvar: bool = True, bias: bool = False) -> "Tensor":
         correction = 0 if bias else 1
-        return torch.cov(x, rowvar=rowvar, correction=correction)
+        if not rowvar:
+            x = torch.transpose(x, -2, -1)
+        return torch.cov(x, correction=correction)
 
     def det(self, x: "Tensor") -> "Tensor":
         return torch.linalg.det(x)

--- a/scoringrules/backend/torch.py
+++ b/scoringrules/backend/torch.py
@@ -286,3 +286,13 @@ class TorchBackend(ArrayBackend):
             index_grids = torch.meshgrid(*ranges, indexing="ij")
             indices = torch.stack(index_grids)
         return indices
+
+    def inv(self, x: "Tensor") -> "Tensor":
+        return torch.linalg.inv(x)
+
+    def cov(self, x: "Tensor", rowvar: bool = True, bias: bool = False) -> "Tensor":
+        correction = 0 if bias else 1
+        return torch.cov(x, rowvar=rowvar, correction=correction)
+
+    def det(self, x: "Tensor") -> "Tensor":
+        return torch.linalg.det(x)

--- a/scoringrules/core/dss/__init__.py
+++ b/scoringrules/core/dss/__init__.py
@@ -1,8 +1,9 @@
 try:
-    from ._gufuncs import _dss_gufunc
+    from ._gufuncs import _dss_mv_gufunc, _dss_uv_gufunc
 except ImportError:
-    _dss_gufunc = None
+    _dss_uv_gufunc = None
+    _dss_mv_gufunc = None
 
-from ._score import ds_score as dss
+from ._score import ds_score_uv, ds_score_mv
 
-__all__ = ["dss", "_dss_gufunc"]
+__all__ = ["ds_score_uv", "_dss_uv_gufunc", "ds_score_mv", "_dss_mv_gufunc"]

--- a/scoringrules/core/dss/__init__.py
+++ b/scoringrules/core/dss/__init__.py
@@ -1,10 +1,8 @@
 try:
-    from ._gufuncs import (
-        _dss_gufunc,
-    )
+    from ._gufuncs import _dss_gufunc
 except ImportError:
     _dss_gufunc = None
 
-from ._score import _ds_score as _dss
+from ._score import ds_score as dss
 
-__all__ = ["_dss_gufunc", "_dss"]
+__all__ = ["dss", "_dss_gufunc"]

--- a/scoringrules/core/dss/_gufuncs.py
+++ b/scoringrules/core/dss/_gufuncs.py
@@ -1,12 +1,23 @@
 import numpy as np
 from numba import guvectorize
 
-from scoringrules.core.utils import lazy_gufunc_wrapper_mv
+from scoringrules.core.utils import lazy_gufunc_wrapper_uv, lazy_gufunc_wrapper_mv
+
+
+@lazy_gufunc_wrapper_uv
+@guvectorize("(),(n),()->()")
+def _dss_uv_gufunc(obs: np.ndarray, fct: np.ndarray, bias: bool, out: np.ndarray):
+    ens_mean = np.mean(fct)
+    correction = 0 if bias else 1
+    sig = np.std(fct, ddof=correction)
+    log_sig = 2 * np.log(sig)
+    bias_precision = ((obs - ens_mean) / sig) ** 2
+    out[0] = bias_precision + log_sig
 
 
 @lazy_gufunc_wrapper_mv
 @guvectorize("(d),(m,d),()->()")
-def _dss_gufunc(obs: np.ndarray, fct: np.ndarray, bias: bool, out: np.ndarray):
+def _dss_mv_gufunc(obs: np.ndarray, fct: np.ndarray, bias: bool, out: np.ndarray):
     M = fct.shape[0]
     ens_mean = np.sum(fct, axis=0) / M
     obs_cent = obs - ens_mean

--- a/scoringrules/core/dss/_gufuncs.py
+++ b/scoringrules/core/dss/_gufuncs.py
@@ -5,9 +5,10 @@ from scoringrules.core.utils import lazy_gufunc_wrapper_mv
 
 
 @lazy_gufunc_wrapper_mv
-@guvectorize("(d),(m,d)->()")
+@guvectorize("(d),(m,d),()->()")
 def _dss_gufunc(obs: np.ndarray, fct: np.ndarray, bias: bool, out: np.ndarray):
-    ens_mean = np.mean(fct, axis=-2)
+    M = fct.shape[0]
+    ens_mean = np.sum(fct, axis=0) / M
     obs_cent = obs - ens_mean
     cov = np.cov(fct, rowvar=False, bias=bias)
     prec = np.linalg.inv(cov)

--- a/scoringrules/core/dss/_gufuncs.py
+++ b/scoringrules/core/dss/_gufuncs.py
@@ -8,8 +8,11 @@ from scoringrules.core.utils import lazy_gufunc_wrapper_uv, lazy_gufunc_wrapper_
 @guvectorize("(),(n),()->()")
 def _dss_uv_gufunc(obs: np.ndarray, fct: np.ndarray, bias: bool, out: np.ndarray):
     ens_mean = np.mean(fct)
-    correction = 0 if bias else 1
-    sig = np.std(fct, ddof=correction)
+    fact = len(fct) - 1.0
+    if bias:
+        fact += 1.0
+    var = np.sum((fct - ens_mean) ** 2) / fact
+    sig = np.sqrt(var)
     log_sig = 2 * np.log(sig)
     bias_precision = ((obs - ens_mean) / sig) ** 2
     out[0] = bias_precision + log_sig

--- a/scoringrules/core/dss/_score.py
+++ b/scoringrules/core/dss/_score.py
@@ -15,15 +15,15 @@ def ds_score(
     """Compute the Dawid Sebastiani Score for a multivariate finite ensemble."""
     B = backends.active if backend is None else backends[backend]
 
-    *batch_dims, _, D = fct.shape
+    batch_dims = fct.shape[:-2]
     out = B.zeros(batch_dims)
 
     # nested loop over all batch dimensions
     def recursive_loop(current_index, depth):
         if depth == len(batch_dims):
             fct_i = fct[tuple(current_index)]  # (M, D)
-            obs_i = obs[tuple(current_index)]
-            score = ds_score_mat(obs_i, fct_i, bias)  # shape (D, D)
+            obs_i = obs[tuple(current_index)]  # (D)
+            score = ds_score_mat(obs_i, fct_i, bias, backend=backend)  # ()
             out[tuple(current_index)] = score
             return
 

--- a/scoringrules/core/dss/_score.py
+++ b/scoringrules/core/dss/_score.py
@@ -6,16 +6,47 @@ if tp.TYPE_CHECKING:
     from scoringrules.core.typing import Array, Backend
 
 
-def _ds_score(
+def ds_score(
     obs: "Array",  # (... D)
     fct: "Array",  # (... M D)
+    bias: bool = False,
     backend: "Backend" = None,
 ) -> "Array":
-    """Compute the Dawid Sebastiani score Score for a multivariate finite ensemble."""
+    """Compute the Dawid Sebastiani Score for a multivariate finite ensemble."""
     B = backends.active if backend is None else backends[backend]
-    cov = B.cov(fct)
-    precision = B.inv(cov)
-    log_det = B.log(B.det(cov))
-    bias = obs - B.mean(fct, axis=-2)
-    bias_precision = B.squeeze(bias[:, None, :] @ precision @ bias[:, :, None])
-    return log_det + bias_precision
+
+    *batch_dims, _, D = fct.shape
+    out = B.zeros(batch_dims)
+
+    # nested loop over all batch dimensions
+    def recursive_loop(current_index, depth):
+        if depth == len(batch_dims):
+            fct_i = fct[tuple(current_index)]  # (M, D)
+            obs_i = obs[tuple(current_index)]
+            score = ds_score_mat(obs_i, fct_i, bias)  # shape (D, D)
+            out[tuple(current_index)] = score
+            return
+
+        for i in range(batch_dims[depth]):
+            recursive_loop(current_index + [i], depth + 1)
+
+    recursive_loop([], 0)
+    return out
+
+
+def ds_score_mat(
+    obs: "Array",  # (D)
+    fct: "Array",  # (M D)
+    bias: bool = False,
+    backend: "Backend" = None,
+) -> "Array":
+    """Compute the Dawid Sebastiani Score for one multivariate finite ensemble."""
+    B = backends.active if backend is None else backends[backend]
+    cov = B.cov(fct, rowvar=False, bias=bias)  # (D D)
+    precision = B.inv(cov)  # (D D)
+    log_det = B.log(B.det(cov))  # ()
+    obs_cent = obs - B.mean(fct, axis=-2)  # (D)
+    bias_precision = B.squeeze(
+        B.expand_dims(obs_cent, axis=-2) @ precision @ B.expand_dims(obs_cent, axis=-1)
+    )  # ()
+    return bias_precision + log_det

--- a/scoringrules/core/dss/_score.py
+++ b/scoringrules/core/dss/_score.py
@@ -15,9 +15,8 @@ def ds_score_uv(
     """Compute the Dawid Sebastiani Score for a univariate finite ensemble."""
     B = backends.active if backend is None else backends[backend]
     ens_mean = B.mean(fct, axis=-1)
-    obs_cent = obs - ens_mean
     sig = B.std(fct, axis=-1, bias=bias)
-    bias_precision = ((obs_cent - ens_mean) / sig) ** 2
+    bias_precision = ((obs - ens_mean) / sig) ** 2
     log_sig = 2 * B.log(sig)
     return bias_precision + log_sig
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 from scoringrules.backend import backends
 
 DATA_DIR = Path(__file__).parent / "data"
-RUN_TESTS = ["numpy", "numba", "torch"]
+RUN_TESTS = ["numpy", "numba", "jax", "torch"]
 BACKENDS = [b for b in backends.available_backends if b in RUN_TESTS]
 
 if os.getenv("SR_TEST_OUTPUT", "False").lower() in ("true", "1", "t"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 from scoringrules.backend import backends
 
 DATA_DIR = Path(__file__).parent / "data"
-RUN_TESTS = ["numpy", "numba", "jax", "torch"]
+RUN_TESTS = ["numpy", "numba", "torch"]
 BACKENDS = [b for b in backends.available_backends if b in RUN_TESTS]
 
 if os.getenv("SR_TEST_OUTPUT", "False").lower() in ("true", "1", "t"):

--- a/tests/test_dss.py
+++ b/tests/test_dss.py
@@ -10,16 +10,40 @@ N_VARS = 3
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
-def test_ds_score(backend):
+def test_ds_score_uv(backend):
+    obs = np.random.randn(N)
+    mu = obs + np.random.randn(N) * 0.1
+    sigma = abs(np.random.randn(N)) * 0.3
+    fct = np.random.randn(N, ENSEMBLE_SIZE) * sigma[..., None] + mu[..., None]
+
+    # m_axis keyword
+    res = sr.dssuv_ensemble(
+        obs,
+        np.random.randn(ENSEMBLE_SIZE, N),
+        m_axis=0,
+        backend=backend,
+    )
+    res = np.asarray(res)
+    assert res.shape == (N,)
+
+    # test correctness
+    obs, fct = 11.6, np.array([9.8, 8.7, 11.9, 12.1, 13.4])
+    res = sr.dssuv_ensemble(obs, fct, bias=True, backend=backend)
+    expected = 1.115645
+    assert np.isclose(res, expected)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_ds_score_mv(backend):
     with pytest.raises(ValueError):
         obs = np.random.randn(N, N_VARS)
         fct = np.random.randn(N, ENSEMBLE_SIZE, N_VARS - 1)
-        sr.dss_ensemble(obs, fct, backend=backend)
+        sr.dssmv_ensemble(obs, fct, backend=backend)
 
     # test shapes
     obs = np.random.randn(N, N_VARS)
     fct = np.expand_dims(obs, axis=-2) + np.random.randn(N, ENSEMBLE_SIZE, N_VARS)
-    res = sr.dss_ensemble(obs, fct, backend=backend)
+    res = sr.dssmv_ensemble(obs, fct, backend=backend)
     assert res.shape == (N,)
 
     # test correctness
@@ -27,15 +51,15 @@ def test_ds_score(backend):
         [[0.79546742, 0.4777960, 0.2164079], [0.02461368, 0.7584595, 0.3181810]]
     ).T
     obs = np.array([0.2743836, 0.8146400])
-    res = sr.dss_ensemble(obs, fct, backend=backend)
+    res = sr.dssmv_ensemble(obs, fct, backend=backend)
     expected = -3.161553
     np.testing.assert_allclose(res, expected, atol=1e-6)
 
     # test correctness
     fct = np.random.randn(2, 3, 100, 4)
     obs = np.random.randn(2, 3, 4)
-    res = sr.dss_ensemble(obs, fct, backend=backend)
+    res = sr.dssmv_ensemble(obs, fct, backend=backend)
     for i in range(2):
         for j in range(3):
-            res_ij = sr.dss_ensemble(obs[i, j, :], fct[i, j, :, :], backend=backend)
+            res_ij = sr.dssmv_ensemble(obs[i, j, :], fct[i, j, :, :], backend=backend)
             np.testing.assert_allclose(res[i, j], res_ij, atol=1e-6)

--- a/tests/test_dss.py
+++ b/tests/test_dss.py
@@ -1,0 +1,41 @@
+import numpy as np
+import pytest
+import scoringrules as sr
+
+from .conftest import BACKENDS
+
+ENSEMBLE_SIZE = 11
+N = 20
+N_VARS = 3
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_ds_score(backend):
+    with pytest.raises(ValueError):
+        obs = np.random.randn(N, N_VARS)
+        fct = np.random.randn(N, ENSEMBLE_SIZE, N_VARS - 1)
+        sr.dss_ensemble(obs, fct, backend=backend)
+
+    # test shapes
+    obs = np.random.randn(N, N_VARS)
+    fct = np.expand_dims(obs, axis=-2) + np.random.randn(N, ENSEMBLE_SIZE, N_VARS)
+    res = sr.dss_ensemble(obs, fct, backend=backend)
+    assert res.shape == (N,)
+
+    # test correctness
+    fct = np.array(
+        [[0.79546742, 0.4777960, 0.2164079], [0.02461368, 0.7584595, 0.3181810]]
+    ).T
+    obs = np.array([0.2743836, 0.8146400])
+    res = sr.dss_ensemble(obs, fct, backend=backend)
+    expected = -3.161553
+    np.testing.assert_allclose(res, expected, atol=1e-6)
+
+    # test correctness
+    fct = np.random.randn(2, 3, 100, 4)
+    obs = np.random.randn(2, 3, 4)
+    res = sr.dss_ensemble(obs, fct, backend=backend)
+    for i in range(2):
+        for j in range(3):
+            res_ij = sr.dss_ensemble(obs[i, j, :], fct[i, j, :, :], backend=backend)
+            np.testing.assert_allclose(res[i, j], res_ij, atol=1e-6)

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -303,19 +303,19 @@ def test_owgksuv(backend):
 
     # no argument given
     resw = sr.owgksuv_ensemble(obs, fct, backend=backend)
-    np.testing.assert_allclose(res, resw, rtol=1e-2)
+    np.testing.assert_allclose(res, resw, atol=1e-6)
 
     # a and b
     resw = sr.owgksuv_ensemble(
         obs, fct, a=float("-inf"), b=float("inf"), backend=backend
     )
-    np.testing.assert_allclose(res, resw, rtol=1e-2)
+    np.testing.assert_allclose(res, resw, atol=1e-6)
 
     # w_func as identity function
     resw = sr.owgksuv_ensemble(
         obs, fct, w_func=lambda x: x * 0.0 + 1.0, backend=backend
     )
-    np.testing.assert_allclose(res, resw, rtol=1e-2)
+    np.testing.assert_allclose(res, resw, atol=1e-6)
 
     # test correctness
     fct = np.array(


### PR DESCRIPTION
Add Dawid-Sebastiani scores for ensemble forecasts (closes #32):
- Addresses the remaining tasks listed in #75
- Adds univariate and multivariate Dawid-Sebastiani score
- Adds tests to check that the scores align with scoringRules in R
- Batch covariance matrix is calculated by looping over all dimensions, which is not very elegant but does work. This can be replaced if a better alternative is thought of 