### PR TITLE
Add DSS to Docs

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -26,6 +26,8 @@ Univariate
     vrgksuv_ensemble
     crps_quantile
 
+    dssuv_ensemble
+
 Multivariate
 --------------------
 
@@ -46,6 +48,8 @@ Multivariate
     twgksmv_ensemble
     owgksmv_ensemble
     vrgksmv_ensemble
+
+    dssmv_ensemble
 
 Parametric distributions forecasts
 ====================================


### PR DESCRIPTION
Hi @frazane, @sallen12 

this is a mini PR to add the DSS to the docs.

Minor suggestion: Maybe add L2 Headings for the scores (CRPS, ES, ....) in the API reference, currently the list is hard to skim.

