### PR TITLE
CI: workflow hygiene + coverage fold

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,69 +7,63 @@ on:
     branches: [main]
   workflow_dispatch: {}
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   test:
-
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest]
         python-version: ["3.12", "3.13", "3.14"]
         backend: [numpy, numba, jax, torch]
+        include:
+          # Coverage leg: full suite, all backends, one Python/OS. Folded in
+          # from the former standalone `coverage:` job (spec A8).
+          - os: ubuntu-latest
+            python-version: "3.13"
+            backend: all
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v2
+        uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install the project
         run: |
-          if [ "${{ matrix.backend }}" = "numpy" ]; then
+          if [ "${{ matrix.backend }}" = "all" ]; then
+            uv sync --all-extras --dev
+          elif [ "${{ matrix.backend }}" = "numpy" ]; then
             uv sync
           else
             uv sync --extra ${{ matrix.backend }}
           fi
 
       - name: Run tests
-        run: uv run pytest tests/ --backend ${{matrix.backend }}
-
-  coverage:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v2
-        with:
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-
-      - name: Install the project
-        run: uv sync --all-extras --dev
+        if: matrix.backend != 'all'
+        run: uv run pytest tests/ --backend ${{ matrix.backend }}
 
       - name: Run tests with coverage
+        if: matrix.backend == 'all'
         run: |
           uv run pytest --cov=scoringrules tests/
           uv run coverage xml
 
       - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@v4
+        if: matrix.backend == 'all'
+        uses: codecov/codecov-action@v5
         with:
           file: ./coverage.xml
           flags: unittests
@@ -78,18 +72,18 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
-
   lint:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v2
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+          python-version: "3.13"
 
       - name: Run pre-commit hooks
         run: uvx pre-commit run --all-files

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,6 @@ jobs:
         with:
           files: ./coverage.xml
           flags: unittests
-          env_vars: OS,PYTHON
           name: codecov-umbrella
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
         if: matrix.backend == 'all'
         uses: codecov/codecov-action@v5
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           flags: unittests
           env_vars: OS,PYTHON
           name: codecov-umbrella


### PR DESCRIPTION
First step in tidying up the CI workflow. This bumps stale action versions, removes some redundant setup, hardens permissions, and folds the separate coverage job into the test matrix so the same suite isn't run twice.

**What changed**

- Bumped actions to current majors: checkout v5, setup-uv v6, codecov-action v5.
- Let uv install/pin Python via setup-uv's python-version input and dropped the separate setup-python step; the lint job now caches too.
- Added a concurrency group so superseded runs are cancelled, and set fail-fast: false so one backend failing no longer cancels the other legs.
- Added top-level permissions: contents: read.
- Removed the standalone coverage job and added a single matrix leg (ubuntu, 3.13, all extras) that runs the full suite with coverage and uploads to Codecov.

**Notes**

- The test matrix is now 24 per-backend legs plus one coverage leg. Worth confirming the 3.14 jax/torch legs are happy with uv-managed Python.