### PR TITLE
Add Dependabot for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "ci"


### PR DESCRIPTION
Adds Dependabot so GitHub Actions versions stay current on their own instead of drifting. This keeps the recently-bumped action versions from going stale again.

**What changed**

- Added .github/dependabot.yml for the github-actions ecosystem on a weekly schedule.
- Grouped all action updates into a single PR (rolling) rather than one PR per action, to keep the noise down.
- Tagged the resulting PRs with the ci label and a ci commit-message prefix.

**Notes**

- Python dependency updates are intentionally left out for now; can be added later if wanted.