### PR TITLE
Add contributor templates, PR labeler, and release-note categories

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,53 @@
+name: Bug report
+description: Report incorrect behavior or a crash in scoringrules
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting! scoringrules runs the same scoring code across
+        multiple array backends, so the backend and versions below are essential.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you observe, and what did you expect instead?
+      placeholder: "crps_ensemble returns NaN where a finite score is expected…"
+    validations:
+      required: true
+  - type: textarea
+    id: reproducer
+    attributes:
+      label: Minimal reproducer
+      description: A self-contained snippet that triggers the bug.
+      render: python
+    validations:
+      required: true
+  - type: dropdown
+    id: backend
+    attributes:
+      label: Backend
+      description: Which array backend exhibits the bug?
+      multiple: true
+      options:
+        - numpy
+        - numba
+        - jax
+        - torch
+    validations:
+      required: true
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      placeholder: "3.13"
+    validations:
+      required: true
+  - type: input
+    id: sr-version
+    attributes:
+      label: scoringrules version
+      description: "Output of `python -c 'import scoringrules; print(scoringrules.__version__)'`"
+      placeholder: "0.10.0"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,24 @@
+name: Feature request
+description: Suggest a new score, backend, or capability
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What are you trying to do that scoringrules doesn't support today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would the API or behavior look like? Cite a reference if it's a known scoring rule.
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+## Summary
+
+<!-- What does this PR do and why? -->
+
+## Checklist
+
+- [ ] Tests pass across all backends (`uv run pytest tests/` — numpy, numba, jax, torch)
+- [ ] New/changed numerics touch both the array-API and numba paths where applicable
+- [ ] Docs / docstrings updated if public behavior changed
+- [ ] A release-note label is applied (`feature`, `fix`, `backend`, `docs`, or `ci`)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 ## Checklist
 
-- [ ] Tests pass across all backends (`uv run pytest tests/` — numpy, numba, jax, torch)
+- [ ] Tests pass across all backends — `uv sync --all-extras --dev` then `uv run pytest tests/` (exercises every installed backend: numpy, numba, jax, torch)
 - [ ] New/changed numerics touch both the array-API and numba paths where applicable
 - [ ] Docs / docstrings updated if public behavior changed
-- [ ] A release-note label is applied (`feature`, `fix`, `backend`, `docs`, or `ci`)
+- [ ] A release-note label is applied (`breaking`, `feature`, `fix`, `backend`, `docs`, or `ci`)

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,26 @@
+core:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "scoringrules/_*.py"
+          - "scoringrules/core/**"
+
+docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
+          - "**/*.md"
+
+"backend:jax":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "scoringrules/backend/jax.py"
+
+"backend:torch":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "scoringrules/backend/torch.py"
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,27 @@
+changelog:
+  categories:
+    - title: Breaking changes
+      labels:
+        - breaking
+    - title: New features
+      labels:
+        - feature
+        - enhancement
+    - title: Bug fixes
+      labels:
+        - fix
+        - bug
+    - title: Backend-specific
+      labels:
+        - backend
+        - "backend:jax"
+        - "backend:torch"
+    - title: Documentation
+      labels:
+        - docs
+    - title: CI / tooling
+      labels:
+        - ci
+    - title: Other changes
+      labels:
+        - "*"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,13 @@
+name: Labeler
+
+on: [pull_request_target]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5


### PR DESCRIPTION
Adds the contributor-facing automation the repo was missing: issue and PR templates, automatic path-based PR labels, and categorized release notes. For a library that runs across multiple backends, the bug template in particular nudges reporters to tell us which backend and versions they hit.

**What changed**

- Issue forms under .github/ISSUE_TEMPLATE/: a bug report that asks for backend, Python version, scoringrules version and a minimal reproducer, plus a feature request form. Blank issues are disabled.
- .github/PULL_REQUEST_TEMPLATE.md with a short checklist (tests across backends, both array-API and numba paths, docs, release-note label).
- .github/release.yml so GitHub's auto-generated release notes are grouped by label, including a Breaking changes section at the top.
- A path-based labeler (.github/labeler.yml + a labeler workflow) that tags PRs as core / docs / ci / backend:jax / backend:torch from the files they touch. These labels feed the release-note categories.

**Notes**

- The labeler runs on pull_request_target so it can label PRs from forks; it only reads the changed-file list and applies labels, it doesn't run PR code.
- Release-note categorization keys off labels on the merged PRs, so cutting a release with good notes means the merged PRs need the right labels applied.