### PR TITLE
Consolidate release-note labels onto GitHub defaults

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,4 +7,4 @@
 - [ ] Tests pass across all backends — `uv sync --all-extras --dev` then `uv run pytest tests/` (exercises every installed backend: numpy, numba, jax, torch)
 - [ ] New/changed numerics touch both the array-API and numba paths where applicable
 - [ ] Docs / docstrings updated if public behavior changed
-- [ ] A release-note label is applied (`breaking`, `feature`, `fix`, `backend`, `docs`, or `ci`)
+- [ ] A release-note label is applied (`breaking`, `enhancement`, `bug`, `backend`, `documentation`, or `ci`)

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,7 +4,7 @@ core:
           - "scoringrules/_*.py"
           - "scoringrules/core/**"
 
-docs:
+documentation:
   - changed-files:
       - any-glob-to-any-file:
           - "docs/**"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -5,11 +5,9 @@ changelog:
         - breaking
     - title: New features
       labels:
-        - feature
         - enhancement
     - title: Bug fixes
       labels:
-        - fix
         - bug
     - title: Backend-specific
       labels:
@@ -18,7 +16,7 @@ changelog:
         - "backend:torch"
     - title: Documentation
       labels:
-        - docs
+        - documentation
     - title: CI / tooling
       labels:
         - ci


### PR DESCRIPTION
Cleans up the label set introduced with the release-notes automation. The custom labels fix / feature / docs duplicated GitHub's standard bug / enhancement / documentation, so this standardizes on the defaults and points the automation at them.

**What changed**

- release.yml: Bug fixes now keys off bug, New features off enhancement, Documentation off documentation (dropping the redundant fix / feature / docs synonyms).
- labeler.yml: the docs path rule now applies the documentation label.
- Pull request template: the release-note label list matches the categories above.

**Notes**

- The duplicate labels fix / feature / docs are being deleted from the repo as part of this cleanup.
- Existing PRs are being re-labeled to match (documentation instead of docs), and the breaking label is being applied to the Python 3.11 and tensorflow-backend removals so they surface correctly in the next release notes.