### PR TITLE
Fix release workflow trigger (published, not created)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   release:
-    types: [created]
+    types: [published]
   workflow_dispatch:
     inputs:
       target:


### PR DESCRIPTION
The release workflow listened for the `created` release activity type, which does not fire when a release is published through the GitHub UI. As a result the 0.11.0 release published on GitHub but the workflow never ran and nothing was uploaded to PyPI.

**What changed**

- release.yaml now triggers on `release: types: [published]`, the type that fires when a release is published. This is also the trigger recommended in the PyPA publishing guide.

**Notes**

- Release-triggered workflows run from the workflow file on the default branch, so this fix takes effect for the existing 0.11.0 tag once merged — the release just needs to be re-published to fire the event.